### PR TITLE
docs: add Zenodo DOI badge + citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,7 @@ type: software
 license: Apache-2.0
 repository-code: "https://github.com/raphaelrrcoelho/formal-mathfin"
 url: "https://github.com/raphaelrrcoelho/formal-mathfin"
+doi: 10.5281/zenodo.20477782
 version: "1.0.0"
 date-released: "2026-05-31"
 keywords:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![blueprint](https://img.shields.io/badge/blueprint-deductive_spine-blue)](docs/blueprint.md)
 [![Lean](https://img.shields.io/badge/Lean-4.30.0--rc2-blue)](lean-toolchain)
 [![license](https://img.shields.io/badge/license-Apache_2.0-blue)](LICENSE)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20477782.svg)](https://doi.org/10.5281/zenodo.20477782)
 
 A Lean 4 library of machine-checked mathematical-finance theorems, built on Mathlib
 and Degenne's BrownianMotion. 251 theorems across 11 areas — Black-Scholes


### PR DESCRIPTION
adds zenodo doi 10.5281/zenodo.20477782 — readme badge + `CITATION.cff` doi field. docs-only.