### PR TITLE
Contributor-readiness: CoC, issue/PR templates, onboarding & troubleshooting docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Something in the library is wrong — incorrect statement, broken build, stale doc
+title: "Bug: <short description>"
+labels: bug
+assignees: ""
+---
+
+## What is wrong
+
+<!-- Describe the issue. For a proof bug: which theorem, what the stated claim is, and why it is incorrect or misleading. For a build bug: the error message. For a doc bug: which file and what is inaccurate. -->
+
+## How to reproduce
+
+```bash
+# steps / commands to reproduce
+```
+
+## Expected behaviour
+
+<!-- What should happen. -->
+
+## Environment
+
+- Lean toolchain (from `lean-toolchain`):
+- Docker image tag (if applicable):
+- Host OS:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature / tooling request
+about: A new benchmark, Python tool, CI gate, or workflow improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## What and why
+
+<!-- Describe what you want and why it would be useful. -->
+
+## Proposed approach
+
+<!-- Optional: how you would implement it. -->
+
+## Alternatives considered
+
+<!-- Optional: what else you considered and why you ruled it out. -->

--- a/.github/ISSUE_TEMPLATE/theorem_contribution.md
+++ b/.github/ISSUE_TEMPLATE/theorem_contribution.md
@@ -1,0 +1,35 @@
+---
+name: Theorem contribution
+about: Propose formalizing a new theorem or upgrading a reduced_core entry to full
+title: "Formalize: <theorem name>"
+labels: enhancement
+assignees: ""
+---
+
+## Theorem
+
+<!-- State the mathematical result in plain prose + the standard reference (author, year, textbook section). -->
+
+## Lean location
+
+<!-- Where does this belong in MathFin/? Which existing module is the closest neighbour? -->
+
+**Proposed file:** `MathFin/<Section>/<Module>.lean`
+**Benchmark id:** `<domain>-<id>`
+**Proposed status:** `full` / `library_wrapper` / `reduced_core`
+
+## Proof sketch
+
+<!-- 3–5 sentences: the key steps and which Mathlib / BrownianMotion lemmas you expect to consume. -->
+
+## Prerequisites
+
+<!-- Any MathFin modules this depends on. Flag if it is blocked on upstream (Mathlib / Degenne). -->
+
+## Scope honesty
+
+<!-- Is this the full textbook theorem, or an honest narrowing? If narrowing, say exactly what is narrowed. -->
+
+## Size estimate
+
+<!-- Rough LOC and whether you expect one session or multiple. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- One paragraph: what theorem / doc / tooling change does this add, and why. -->
+
+## Checklist
+
+### For Lean proof contributions
+
+- [ ] Proof lives in `MathFin/<Section>/<Module>.lean`, not inlined in JSON (unless it's a single-line library wrapper).
+- [ ] `@[expose] public section` present in the module after the docstring.
+- [ ] `#print axioms <myTheorem>` shows only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.
+- [ ] `lake build` exits cleanly.
+- [ ] `./scripts/lean-check.sh MathFin/<Section>/<Module>.lean` returns `"success": true`.
+- [ ] Benchmark re-export shim added (or updated) in `benchmarks/*.json`.
+- [ ] `metadata.formalization_status` set to `full` / `library_wrapper` / `reduced_core` (never `placeholder` to merge).
+- [ ] `docs/coverage.md` row added / updated.
+- [ ] `python3 -m tools.verify.axiom_audit_gen --write` re-run (regenerates `MathFin/AxiomAuditGen.lean`).
+- [ ] `python3 -m tools.verify.ledger status` exits 0 (all entries fresh).
+- [ ] `docker compose -f docker/docker-compose.yml run --rm --entrypoint python3 verify -m pytest tests/ -q` passes.
+
+### For documentation contributions
+
+- [ ] No dead relative links introduced.
+- [ ] File referenced from `docs/README.md` or the appropriate index if it is new.
+
+### For Python tooling contributions
+
+- [ ] Host-side, Python stdlib only (no new deps unless discussed).
+- [ ] `pytest tests/` passes.
+
+## Related issues
+
+Closes #

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,58 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in this
+project a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when
+an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at **raphaelrrcoelho@gmail.com**. All
+complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,23 @@
 This is a Lean 4 library of formally verified mathematical-finance theorems. The
 canonical verification is `lake build` from the repo root.
 
+Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+**New here?** [`docs/onboarding.md`](docs/onboarding.md) is the step-by-step
+first-contribution walkthrough. [`docs/troubleshooting.md`](docs/troubleshooting.md)
+covers common setup failures. Issues tagged
+[`good first issue`](https://github.com/raphaelrrcoelho/formal-mathfin/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+are the recommended entry points.
+
 ## Getting set up
 
 The fastest path is Docker (pinned Lean toolchain + Mathlib + BrownianMotion):
 
 ```bash
+# Log in to GHCR (one-time per machine — needs gh with read:packages scope):
+TOKEN=$(grep -E '^[[:space:]]+oauth_token:' ~/.config/gh/hosts.yml | head -1 | awk '{print $2}')
+echo "$TOKEN" | docker login ghcr.io -u raphaelrrcoelho --password-stdin
+
 # Pull the prebuilt image (~3 min vs ~15 min local build)
 docker compose -f docker/docker-compose.yml pull verify
 
@@ -18,6 +30,12 @@ docker compose -f docker/docker-compose.yml run --rm --entrypoint bash verify -l
 For host authoring, install elan + the pinned Lean toolchain, then VS Code with
 the Lean extension. The Lake project at repo root is what VS Code's LSP sees;
 no extra config needed.
+
+## PR checklist
+
+Before opening a PR use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`).
+The CI pipeline runs `pytest tests/ -q` → `python3 -m tools.verify.ledger status` →
+`lake build` in that order. A red gate at any step blocks merge.
 
 ## Adding a theorem
 
@@ -61,8 +79,16 @@ no extra config needed.
 7. **Run the regression tests:**
    ```bash
    docker compose -f docker/docker-compose.yml run --rm \
-       --entrypoint python3 verify -m pytest tests/test_router.py -q
+       --entrypoint python3 verify -m pytest tests/ -q
    ```
+
+   All three suites must pass:
+   - `tests/test_router.py` — Lean-only routing, no `sorry`, `@[expose]` rule,
+     `formalization_status` declared on every entry.
+   - `tests/test_ledger.py` — ledger freshness and globally unique ids.
+   - `tests/test_values.py` — no forbidden tactics, no `rfl`-backed `full`
+     entries, blueprint-spine ⊆ curated `AxiomAudit`, byte-fresh
+     `AxiomAuditGen.lean`.
 
 ## Style
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20477782.svg)](https://doi.org/10.5281/zenodo.20477782)
 [![arXiv](https://img.shields.io/badge/arXiv-2606.01356-b31b1b)](https://arxiv.org/abs/2606.01356)
 [![dataset](https://img.shields.io/badge/HF-dataset-ffcc4d)](https://huggingface.co/datasets/raphaelrrcoelho/formal-mathfin-theorems)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa)](CODE_OF_CONDUCT.md)
 
 A Lean 4 library of machine-checked mathematical-finance theorems, built on Mathlib
 and Degenne's BrownianMotion. 274 theorems across 11 areas — Black-Scholes
@@ -249,6 +251,21 @@ Treynor (1965), Sortino-van der Meer (1991), Grinold-Kahn (1999),
 Rockafellar-Uryasev (2000). Black-Scholes (1973), Merton (1973), Black
 (1976), Bachelier (1900), Cox-Ross-Rubinstein (1979). Roncalli-Maillard
 on risk parity, Black-Litterman (1992).
+
+## Contributing
+
+Contributions are welcome — from documentation fixes to new theorem
+formalisations to upstream Mathlib PRs.
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — full development workflow.
+- [`docs/onboarding.md`](docs/onboarding.md) — step-by-step first-contribution
+  walkthrough (environment setup, fast iteration loop, PR checklist).
+- [`docs/troubleshooting.md`](docs/troubleshooting.md) — common setup failures
+  and fixes.
+- [Good first issues](https://github.com/raphaelrrcoelho/formal-mathfin/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+  — labelled tasks with explicit scope, acceptance criteria, and file pointers.
+
+Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,9 @@
 
 | File | One-line | When to read |
 |---|---|---|
-| [`blueprint.md`](blueprint.md) | The deductive spine — a dependency graph from Brownian motion to Black–Scholes, each node linked to its Lean proof. | **First**, to see the BM → Black-Scholes deductive arc and what's proved vs gated. |
+| [`onboarding.md`](onboarding.md) | Step-by-step first-contribution walkthrough: environment, fast REPL loop, module anatomy, PR checklist. | **Start here** if you are making your first contribution. |
+| [`troubleshooting.md`](troubleshooting.md) | Common build/environment failures — symptom → cause → fix. | When something breaks (GHCR login, OOM, inode staleness, daemon slot contention, stale ledger). |
+| [`blueprint.md`](blueprint.md) | The deductive spine — a dependency graph from Brownian motion to Black–Scholes, each node linked to its Lean proof. | To see the BM → Black-Scholes deductive arc and what's proved vs gated. |
 | [`coverage.md`](coverage.md) | Per-theorem audit with faithfulness status and verification evidence. | Before claiming any specific theorem is "proved." Source of truth for what's `full` vs `library_wrapper` vs `reduced_core`. |
 | [`architecture.md`](architecture.md) | Design principles: the seven structural-principle modules, the three-tier honesty model, the bridge methodology. | When deciding where a new theorem belongs, or to understand why the library is shaped the way it is. |
 | [`leaps.md`](leaps.md) | The 2026-05-23 "leaps": static Girsanov (the risk-neutral measure *derived*, `BSCallHyp` made a theorem), the genesis cascade (physical→EMM→pricing spine), and Margrabe's multivariate exchange option. Includes the honest abstraction boundary and what stays gated. | To understand how the EMM stops being an axiom, and how the multivariate / change-of-measure results compose. |

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,168 @@
+# First contribution walkthrough
+
+This guide walks you through making your first contribution to `formal-mathfin`
+from zero to a merged PR. It assumes familiarity with Lean 4 syntax but not
+with this codebase.
+
+## 1. Pick a task
+
+Browse issues labelled
+[`good first issue`](https://github.com/raphaelrrcoelho/formal-mathfin/issues?q=is%3Aopen+label%3A%22good+first+issue%22).
+
+Good entry points by type:
+- **Documentation only** (no build required): glossary, troubleshooting FAQ,
+  cross-linking `docs/coverage.md`, `## Result` docstring audit.
+- **Small Lean proof** (~50–100 LOC): a new Black–Scholes Greek (charm, speed)
+  or the Black-76 caplet — the pattern is fully established, the infrastructure
+  is all there.
+- **Python tooling** (~150–250 LOC): `formalization.yaml` manifest generator.
+
+## 2. Set up the environment
+
+### Docker path (recommended — pins Lean/Mathlib/BrownianMotion)
+
+```bash
+# Log in to GHCR (one-time per machine):
+TOKEN=$(grep -E '^[[:space:]]+oauth_token:' ~/.config/gh/hosts.yml | head -1 | awk '{print $2}')
+echo "$TOKEN" | docker login ghcr.io -u raphaelrrcoelho --password-stdin
+# If the command above fails, refresh gh auth first:
+# gh auth refresh -h github.com -s read:packages
+
+# Pull the pinned image (~3 min):
+docker compose -f docker/docker-compose.yml pull verify
+
+# Sanity check — clean exit means every theorem typechecks:
+docker compose -f docker/docker-compose.yml run --rm --entrypoint bash verify -lc 'lake build'
+```
+
+### VS Code authoring (for Lean edits)
+
+Install [elan](https://github.com/leanprover/elan) and the VS Code Lean 4
+extension. Open the repo root — the `lakefile.lean` is the project root. The
+LSP picks up `MathFin/` automatically; `loogle`/`apply?`/`exact?` work
+transitively through Mathlib.
+
+## 3. Fast iteration loop (5–30 s per check)
+
+Instead of a cold `lake build` (5–15 min), use the persistent REPL daemon:
+
+```bash
+# Start the daemon (once per session, wait for "READY"):
+docker compose -f docker/docker-compose.yml up -d lean-repl
+docker compose -f docker/docker-compose.yml logs -f lean-repl | grep -m1 READY
+
+# Check a file after each edit:
+./scripts/lean-check.sh MathFin/BlackScholes/PDE.lean
+# Returns JSON: {"success": bool, "errors": [...], "warnings": [...], "sorry_count": N}
+
+# Check a single benchmark snippet:
+./scripts/bench-check.sh benchmarks/mathematical_finance.json mf-bs-delta
+
+# Tear down at end of session:
+docker compose -f docker/docker-compose.yml down lean-repl
+```
+
+> **Memory rule:** never run two Lean-loaded processes simultaneously.
+> Daemon up → no `lake build`, no `verify` runs. See
+> [troubleshooting.md](troubleshooting.md) if you hit OOM.
+
+## 4. Understand the library layout
+
+```
+MathFin/
+  Foundations/       # probability primitives, Itô, FTAP, pricing kernels
+  BlackScholes/      # BS formula, Greeks, exotics, PDE, Merton jump-diffusion
+  Binomial/          # CRR, American/Bermudan, Snell, reflection principle
+  Futures/           # Black-76, swaption
+  FixedIncome/       # ZCB, duration, credit, Vasicek
+  Portfolio/         # Markowitz, CAPM, Black-Litterman, risk parity
+  Performance/       # Sharpe, Sortino, Treynor, Kelly
+  RiskMeasures/      # VaR, CVaR, coherent axioms
+  Actuarial/         # annuity, net premium, Gompertz
+  DeFi/              # constant-product AMM
+  Examples.lean      # curated five-proof tour — start here
+```
+
+Every module **must** have `@[expose] public section` after its docstring
+(otherwise its declarations are module-private and benchmark snippets break).
+
+Non-trivial proofs live in `.lean` files here. Benchmark JSONs contain only
+5–25 line re-export shims (`import MathFin.<Section>.<Module>` + a reference to
+the named lemma).
+
+## 5. Anatomy of a module file
+
+```lean
+/-
+Copyright (c) 2026 Your Name. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Your Name
+
+## Result
+
+`myTheorem` : <one-line description>.
+-/
+
+import MathFin.Foundations.GaussianCDFDeriv
+import Mathlib.Analysis.SpecialFunctions.Gaussian
+
+@[expose] public section
+
+open MeasureTheory
+
+/-- The main result. -/
+theorem myTheorem ... := by
+  ...
+```
+
+## 6. Check axioms-cleanliness
+
+Every `full` theorem must depend only on the three Mathlib standard axioms:
+
+```lean
+#print axioms myTheorem
+-- expected: [propext, Classical.choice, Quot.sound]
+```
+
+Anything else (especially `sorryAx`) means the proof has a gap and cannot merge.
+
+## 7. Update the audit trail
+
+After the proof builds:
+
+```bash
+# 1. Add/update docs/coverage.md row (file, theorem name, status, evidence).
+# 2. Regenerate the exhaustive axiom audit:
+python3 -m tools.verify.axiom_audit_gen --write
+
+# 3. Refresh the verification ledger:
+python3 -m tools.verify.ledger status   # shows fresh/stale/missing
+# If stale entries: start the daemon and run:
+python3 -m tools.verify.ledger verify
+```
+
+## 8. Run the gates
+
+```bash
+docker compose -f docker/docker-compose.yml run --rm \
+    --entrypoint python3 verify -m pytest tests/ -q
+```
+
+All three test files must pass:
+- `tests/test_router.py` — routing, Lean-only code keys, no sorry, `@[expose]` rule, formalization_status.
+- `tests/test_ledger.py` — ledger freshness and unique ids.
+- `tests/test_values.py` — no forbidden tactics, no `rfl`-backed `full` entries, blueprint ⊆ audit.
+
+## 9. Open the PR
+
+Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`). Tick every box that
+applies. The CI pipeline runs `pytest` + `ledger status` + `lake build` — a
+red CI means the PR is not ready to merge.
+
+## Where to ask for help
+
+- Open a GitHub issue with a question label, or comment on the issue you're
+  working on.
+- The `docs/patterns.md` file is the distilled pattern catalogue — check it
+  before asking "how do I prove X in this style."
+- `docs/troubleshooting.md` covers common setup failures.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,171 @@
+# Build & environment troubleshooting
+
+Quick reference for common failures. Each entry follows: **symptom → cause → fix**.
+
+---
+
+## GHCR `docker pull` fails with "unauthorized"
+
+**Symptom:** `docker compose pull verify` returns `unauthorized: unauthenticated`.
+
+**Cause:** You are not logged in to the GitHub Container Registry, or your
+OAuth token does not have the `read:packages` scope.
+
+**Fix:**
+```bash
+# Refresh the gh auth scope first if needed:
+gh auth refresh -h github.com -s read:packages
+
+# Then log in:
+TOKEN=$(grep -E '^[[:space:]]+oauth_token:' ~/.config/gh/hosts.yml | head -1 | awk '{print $2}')
+echo "$TOKEN" | docker login ghcr.io -u raphaelrrcoelho --password-stdin
+
+# Retry the pull:
+docker compose -f docker/docker-compose.yml pull verify
+```
+
+---
+
+## "unknown constant" after editing a single-file bind mount
+
+**Symptom:** `lean-check.sh` or a benchmark run returns `unknown constant
+'MathFin.SomeModule.someDecl'` — even though `lake build` succeeds and the
+file looks correct.
+
+**Cause:** Single-file bind mounts (`MathFin.lean`, `lakefile.lean`,
+`lake-manifest.json`, `lean-toolchain`, `mathfin.toml`) pin the inode at
+container start. Rename-based writes — Claude's Edit/Write tools, `sed -i`,
+`mv` — replace the host inode, so a running container silently reads the old
+content.
+
+**Fix:** Re-sync the file into the running container:
+```bash
+docker exec -i docker-lean-repl-1 sh -c 'cat > /app/MathFin.lean' < MathFin.lean
+# Or restart the service:
+docker compose -f docker/docker-compose.yml restart lean-repl
+```
+
+Directory-mounted trees (`MathFin/`, `benchmarks/`, etc.) are not affected —
+edits to files inside those directories are visible immediately.
+
+---
+
+## Container exits with code 137 (OOM kill)
+
+**Symptom:** A `docker compose run` or the `lean-repl` service exits with
+`exit code 137` and nothing in the logs after "Checking …".
+
+**Cause:** Two Lean-loaded processes ran simultaneously, overcommitting
+available RAM. The library is ~4–5 GB when loaded; two processes exceed the
+WSL/host cap and the kernel OOM-kills the container.
+
+**Fix:**
+1. Check whether the `lean-repl` daemon is already running:
+   ```bash
+   docker compose -f docker/docker-compose.yml ps
+   ```
+2. If the daemon is up, **stop it** before running `lake build` or `verify`:
+   ```bash
+   docker compose -f docker/docker-compose.yml down lean-repl
+   # Now run the build:
+   docker compose -f docker/docker-compose.yml run --rm --entrypoint bash verify -lc 'lake build'
+   ```
+3. Never run `leanchecker`, a `verify` run, and the `lean-repl` daemon at the same time.
+
+If you need parallel heavy work, use a remote machine via SSH tunnel:
+```bash
+ssh -L 7878:localhost:7878 <bigger-box>
+# lean-check.sh / bench-check.sh speak to the remote daemon transparently.
+```
+
+---
+
+## Daemon up but `lean-check.sh` is slow (falls back to cold path)
+
+**Symptom:** `lean-check.sh` prints "daemon not reachable, falling back to
+`lake env lean`" and takes 5–15 min instead of 5–30 s.
+
+**Cause:** The daemon is not running, or its TCP port is not yet bound.
+
+**Fix:**
+```bash
+# Start the daemon and wait for READY:
+docker compose -f docker/docker-compose.yml up -d lean-repl
+docker compose -f docker/docker-compose.yml logs -f lean-repl | grep -m1 READY
+# Now re-run lean-check.sh — it will use the fast path.
+```
+
+The daemon takes ~5 min to start (Mathlib + BrownianMotion + MathFin olean
+load). You pay that cost once per session.
+
+---
+
+## `lake build` and `lean-repl` slot contention
+
+**Symptom:** Running `lake build` while the daemon is up causes one of them
+to stall or OOM.
+
+**Cause:** Both `lake build` and the daemon load the Mathlib environment
+into memory. Two simultaneous loads overcommit RAM.
+
+**Fix:** The `lean_interact_cache` Docker volume and the `lake_build_cache`
+named volume are shared; never run a build in one service while the other is
+up.
+
+```bash
+# Take down the daemon before a manual build:
+docker compose -f docker/docker-compose.yml down lean-repl
+docker compose -f docker/docker-compose.yml run --rm --entrypoint bash verify -lc 'lake build'
+# Bring the daemon back up after:
+docker compose -f docker/docker-compose.yml up -d lean-repl
+```
+
+---
+
+## `lake build` succeeds but the daemon still reports errors for a file
+
+**Symptom:** `lake build` exits clean, but `lean-check.sh` reports errors for
+a file that imports a module you just changed.
+
+**Cause:** The daemon does not write `.olean`s for downstream imports. Once a
+proof works in the daemon, the oleans are not updated until `lake build` (or a
+daemon restart) runs.
+
+**Fix:** After editing a module that other files import, restart the daemon or
+run a quick `lake build` to regenerate the oleans, then re-probe.
+
+---
+
+## Ledger shows stale entries after an edit
+
+**Symptom:** `python3 -m tools.verify.ledger status` prints `STALE` for one
+or more entries after you edited a `MathFin/` file or benchmark snippet.
+
+**Cause:** The ledger hashes the snippet code + transitive imports + toolchain
+pins; any change to those inputs marks the entry stale.
+
+**Fix:**
+```bash
+# With the daemon running:
+python3 -m tools.verify.ledger verify   # re-verifies only the stale entries
+
+# Check afterwards:
+python3 -m tools.verify.ledger status   # should show all FRESH
+```
+
+Do not push with stale ledger entries — the CI `ledger status` gate will fail.
+
+---
+
+## CI fails on `test_values.py` after a benchmark edit
+
+**Symptom:** `tests/test_values.py` fails with "stale AxiomAuditGen" or a
+forbidden-text/rfl-backed-full violation.
+
+**Fix:**
+1. For stale audit: regenerate with `python3 -m tools.verify.axiom_audit_gen --write`.
+2. For forbidden text (`sorry`/`admit`/`native_decide`/`polyrith`/`?`-tactics/
+   `hammer`/`loogle`/`leansearch` in `MathFin/` source): remove the tactic.
+   Comments are exempt.
+3. For `rfl`-backed `full`: the proof must do real work — a definition +
+   single `rfl` is `reduced_core`, not `full`.


### PR DESCRIPTION
## Summary

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, enforcement contact set to repo maintainer email.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — full checklist matching the CI pipeline: axioms-clean, benchmark shim, coverage row, `AxiomAuditGen` re-run, ledger freshness, all three test suites.
- **`.github/ISSUE_TEMPLATE/`** — three templates: theorem contribution (scope, proof sketch, size estimate), bug report (symptom/reproduce/env), and feature/tooling request.
- **`docs/onboarding.md`** — step-by-step first-contribution walkthrough: GHCR setup, Docker fast-loop, module anatomy with `@[expose]` rule, axioms-cleanliness check, audit-trail update sequence, PR opening.
- **`docs/troubleshooting.md`** — seven symptom→cause→fix entries covering all failure modes documented in `CLAUDE.md`: GHCR auth, inode-stale single-file bind mounts, OOM/exit-137, daemon cold-path fallback, slot contention, olean staleness, stale ledger.
- **`CONTRIBUTING.md`** — adds CoC link, GHCR login step, PR checklist pointer, full three-suite test list with per-suite descriptions.
- **`README.md`** — adds PRs-welcome + CoC badges; adds a Contributing section linking CONTRIBUTING.md, onboarding, troubleshooting, and the `good first issue` filter.
- **`docs/README.md`** — onboarding and troubleshooting entries added at top of index table.

## Test plan

- [ ] `docs/onboarding.md` and `docs/troubleshooting.md` linked from `docs/README.md` and `CONTRIBUTING.md`.
- [ ] All relative links in new files point to existing paths.
- [ ] No changes to `MathFin/` — `lake build` and `pytest tests/ -q` unaffected.

https://claude.ai/code/session_01NZoorQ7khxurDXGUajgrvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZoorQ7khxurDXGUajgrvf)_