### PR TITLE
autoform: Contango (closes #88)

### DIFF
--- a/MathFin.lean
+++ b/MathFin.lean
@@ -421,3 +421,4 @@ import MathFin.Actuarial.CompoundPoissonMGF
 -- cm-thm-4.3.7; its sibling cm-thm-4.3.9 works only because
 -- Foundations/LpContinuousMartingaleConvergence imports Degenne's DoobLp).
 import BrownianMotion.StochasticIntegral.LocalMartingale
+import MathFin.Futures.Contango

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (265 constants). Scope: proof-position MathFin names only —
+  corpus (266 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -256,6 +256,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.compoundPoisson_mgf' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.compoundPoisson_mgf
+
+/-- info: 'MathFin.contango_backwardation_basis' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.contango_backwardation_basis
 
 /-- info: 'MathFin.couponBondPrice_strictAnti' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.couponBondPrice_strictAnti

--- a/MathFin/Futures/Contango.lean
+++ b/MathFin/Futures/Contango.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 Raphael Coelho. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Coelho
+-/
+module
+
+public import Mathlib
+
+-- pointers: MathFin/BlackScholes/Dividends.lean, MathFin/BlackScholes/Forward.lean
+-- main-module: MathFin/Futures/Contango.lean
+-- benchmark: benchmarks/mathematical_finance.json
+-- benchmark-id: mf-futures-contango
+-- source-issue: 88
+
+/-!
+# Contango, backwardation, and basis convergence
+
+The no-arbitrage forward with a carry / convenience yield `δ` is
+`F(T) = S · exp((r − δ)·T)` (the dividend-yield forward of `BlackScholes/Dividends`,
+where the convenience yield plays the role of a continuous dividend). This records
+the qualitative cost-of-carry sign structure: the market is in **contango**
+(`F > S`) exactly when `r > δ`, in **backwardation** (`F < S`) exactly when
+`r < δ`, and the **basis** `S − F` vanishes at `T = 0`. Pure `Real.exp`
+monotonicity in the effective drift `r − δ`.
+-/
+
+@[expose] public section
+
+namespace MathFin
+
+/-- Cost-of-carry sign structure for the forward `F(T) = S · exp((r − δ)·T)`:
+contango `F > S ↔ r > δ`, backwardation `F < S ↔ r < δ`, and basis convergence
+`F(0) = S`. -/
+theorem contango_backwardation_basis
+    {S r δ T : ℝ} (hS : 0 < S) (hT : 0 < T) :
+    (S < S * Real.exp ((r - δ) * T) ↔ δ < r) ∧
+    (S * Real.exp ((r - δ) * T) < S ↔ r < δ) ∧
+    S * Real.exp ((r - δ) * 0) = S := by
+  have h_third : S * Real.exp ((r - δ) * 0) = S := by simp
+  have h_first : (S < S * Real.exp ((r - δ) * T) ↔ δ < r) := by
+    constructor
+    · intro h
+      have h_one_lt_exp : 1 < Real.exp ((r - δ) * T) := by
+        by_contra hle
+        push_neg at hle
+        have hle' : S * Real.exp ((r - δ) * T) ≤ S := by
+          calc
+            S * Real.exp ((r - δ) * T) ≤ S * 1 := mul_le_mul_of_nonneg_left hle (by linarith)
+            _ = S := by ring
+        linarith
+      have h_mul_pos : 0 < (r - δ) * T := by
+        have h_exp_lt : Real.exp 0 < Real.exp ((r - δ) * T) := by
+          simpa [Real.exp_zero] using h_one_lt_exp
+        exact Real.exp_lt_exp.mp h_exp_lt
+      have h_r_gt_delta : 0 < r - δ := by
+        nlinarith
+      linarith
+    · intro h
+      have h_r_gt_delta : 0 < r - δ := by linarith
+      have h_mul_pos : 0 < (r - δ) * T := by nlinarith
+      have h_exp_lt : Real.exp 0 < Real.exp ((r - δ) * T) := Real.exp_lt_exp.mpr h_mul_pos
+      have h_one_lt_exp : 1 < Real.exp ((r - δ) * T) := by simpa [Real.exp_zero] using h_exp_lt
+      calc
+        S = S * 1 := by ring
+        _ < S * Real.exp ((r - δ) * T) := mul_lt_mul_of_pos_left h_one_lt_exp hS
+  have h_second : (S * Real.exp ((r - δ) * T) < S ↔ r < δ) := by
+    constructor
+    · intro h
+      have h_exp_lt_one : Real.exp ((r - δ) * T) < 1 := by
+        by_contra hle
+        push_neg at hle
+        have hle' : S ≤ S * Real.exp ((r - δ) * T) := by
+          calc
+            S = S * 1 := by ring
+            _ ≤ S * Real.exp ((r - δ) * T) := mul_le_mul_of_nonneg_left hle (by linarith)
+        linarith
+      have h_mul_neg : (r - δ) * T < 0 := by
+        have h_exp_lt : Real.exp ((r - δ) * T) < Real.exp 0 := by
+          simpa [Real.exp_zero] using h_exp_lt_one
+        exact Real.exp_lt_exp.mp h_exp_lt
+      have h_r_lt_delta : r - δ < 0 := by
+        nlinarith
+      linarith
+    · intro h
+      have h_r_lt_delta : r - δ < 0 := by linarith
+      have h_mul_neg : (r - δ) * T < 0 := by nlinarith
+      have h_exp_lt : Real.exp ((r - δ) * T) < Real.exp 0 := Real.exp_lt_exp.mpr h_mul_neg
+      have h_exp_lt_one : Real.exp ((r - δ) * T) < 1 := by simpa [Real.exp_zero] using h_exp_lt
+      calc
+        S * Real.exp ((r - δ) * T) < S * 1 := mul_lt_mul_of_pos_left h_exp_lt_one hS
+        _ = S := by ring
+  exact ⟨h_first, h_second, h_third⟩
+
+end MathFin

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -3598,6 +3598,27 @@
         "formalization_status": "full",
         "formalization_scope": "Full formal proof: FX Esscher tilt + independent-normal decomposition + Gaussian MGF cross-term. Re-export from MathFin. Axioms-clean."
       }
+    },
+    {
+      "id": "mf-futures-contango",
+      "name": "Contango / Backwardation Sign Structure",
+      "description": "For the cost-of-carry forward F(T) = S*e^{(r-delta)T}: contango F>S iff r>delta, backwardation F<S iff r<delta, and basis convergence F(0)=S.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Futures.Contango\n\nopen MathFin\n\n/-- Contango/backwardation sign structure + basis convergence for the\n    cost-of-carry forward F(T) = S*exp((r-delta)T). -/\ntheorem mf_futures_contango {S r delta T : ℝ} (hS : 0 < S) (hT : 0 < T) :\n    (S < S * Real.exp ((r - delta) * T) ↔ delta < r) ∧\n    (S * Real.exp ((r - delta) * T) < S ↔ r < delta) ∧\n    S * Real.exp ((r - delta) * 0) = S :=\n  MathFin.contango_backwardation_basis hS hT\n"
+      },
+      "metadata": {
+        "chapter": 0,
+        "reference": "Cost-of-carry / contango-backwardation (Hull, futures)",
+        "difficulty": "good-first",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/Futures/Contango.lean (Real.exp monotonicity in the effective drift). Re-export from MathFin. Axioms-clean.",
+        "provenance": {
+          "source": "leanstral-autoform",
+          "model": "labs-leanstral-1-5",
+          "issue": 88
+        }
+      }
     }
   ]
 }

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 324 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 310 delivery-ready (full + library-wrapper).
+  scope: 325 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 311 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -46,7 +46,7 @@ automation:
         - labs-leanstral-1-5
       framework: "mathfin-foundry: probe / vibe <-> lean-lsp-mcp"
       tool_setup: token-paced GitHub Actions pipeline; on a pass it opens a ready-for-review PR on formal-mathfin that a human reviews (8-lens values panel) and merges
-      prompting_notes: 0 Leanstral-scouted proof(s) merged
+      prompting_notes: "1 Leanstral-scouted proof(s) merged (closing #88)"
   spend_usd: 0 (Mistral Labs beta)
   notes: "scout, not author: the pipeline opens the PR; a human reviews and merges, so no machine proof enters the library unreviewed"
 fidelity:
@@ -100,9 +100,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 225 statements
+      lean: 226 statements
       module: benchmarks/mathematical_finance.json
-      status: full 224 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 225 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements


### PR DESCRIPTION
this pr was produced by the autoform pipeline (leanstral labs-leanstral-1-5), then assembled and validated green in ci. closes #88.

what it adds:
- `MathFin/Futures/Contango.lean` — the proof (axioms-clean; the probe's axiom guard passed).
- a re-export entry in `benchmarks/mathematical_finance.json`.
- regenerated `MathFin/AxiomAuditGen.lean` + `formalization.yaml`.

provenance: leanstral, run tag `pipeline-20260711`, ~23491 tokens.

review checklist (8-lens, before merge):
- [ ] the statement faithfully formalizes issue #88 (no vacuity, no weaker restatement).
- [ ] the proof is idiomatic and consumes existing lemmas, not a wrapper.
- [ ] ledger row present (run `ledger verify` if ci is red on it).
- [ ] axioms clean; no slop.