### PR TITLE
autoform: FRA (closes #67)

### DIFF
--- a/MathFin.lean
+++ b/MathFin.lean
@@ -423,3 +423,4 @@ import MathFin.Actuarial.SurvivalModel
 -- cm-thm-4.3.7; its sibling cm-thm-4.3.9 works only because
 -- Foundations/LpContinuousMartingaleConvergence imports Degenne's DoobLp).
 import BrownianMotion.StochasticIntegral.LocalMartingale
+import MathFin.FixedIncome.FRA

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (267 constants). Scope: proof-position MathFin names only —
+  corpus (268 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -331,6 +331,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.forward_price_eq_spot_div_discount' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.forward_price_eq_spot_div_discount
+
+/-- info: 'MathFin.fra_value_and_fair_rate' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.fra_value_and_fair_rate
 
 /-- info: 'MathFin.ftap_discrete' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.ftap_discrete

--- a/MathFin/FixedIncome/FRA.lean
+++ b/MathFin/FixedIncome/FRA.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Raphael Coelho. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Coelho
+-/
+module
+
+public import Mathlib
+
+-- pointers: MathFin/FixedIncome/ForwardRate.lean, MathFin/FixedIncome/ZCB.lean
+-- main-module: MathFin/FixedIncome/FRA.lean
+-- benchmark: benchmarks/mathematical_finance.json
+-- benchmark-id: mf-fi-fra
+-- source-issue: 67
+
+/-!
+# Forward-rate agreement: value and the fair simple forward rate
+
+A forward-rate agreement (FRA) over the accrual period `[T₁, T₂]` with year
+fraction `δ = T₂ − T₁` locks a fixed rate `K` against the realised simple rate.
+Writing `P₁ = P(0,T₁)` and `P₂ = P(0,T₂)` for the two zero-coupon discount
+factors (positive reals from the `ZCB` curve), the **simple forward rate** is
+
+  `F = (P₁ / P₂ − 1) / δ`,
+
+the strike that makes the forward loan self-financing. This module records the
+three elementary discount-factor identities of an FRA (`P₂ > 0`, `δ ≠ 0`):
+
+* **No-arbitrage forward rate** — `F` reproduces the replication relation
+  `P₁ = P₂ · (1 + δ · F)` (buy the `T₁`-bond, roll at `F` out to `T₂`).
+* **FRA value in discount factors** — the time-0 value `V = δ · P₂ · (F − K)`
+  is the floating leg minus the fixed leg, `V = (P₁ − P₂) − δ · K · P₂`.
+* **Fair FRA rate** — the value vanishes exactly at the strike `K = F`.
+
+Purely `field_simp` / `ring` algebra over the discount factors; the discrete
+counterpart of the instantaneous `forwardRate` in `ForwardRate.lean`.
+-/
+
+@[expose] public section
+
+namespace MathFin
+
+/-- **FRA value and the fair simple forward rate.** For zero-coupon discount
+factors `P₁ = P(0,T₁)`, `P₂ = P(0,T₂)` (with `P₂ > 0`, accrual `δ ≠ 0`) and the
+simple forward rate `F = (P₁/P₂ − 1)/δ`:
+
+* `P₁ = P₂ · (1 + δ · F)` — `F` is the no-arbitrage forward rate;
+* `δ · P₂ · (F − K) = (P₁ − P₂) − δ · K · P₂` — the FRA value is the floating
+  leg minus the fixed leg;
+* `δ · P₂ · (F − K) = 0 ↔ K = F` — the value vanishes exactly at the fair rate. -/
+theorem fra_value_and_fair_rate
+    {P₁ P₂ δ K F : ℝ} (hP₂ : 0 < P₂) (hδ : δ ≠ 0)
+    (hF : F = (P₁ / P₂ - 1) / δ) :
+    P₁ = P₂ * (1 + δ * F) ∧
+    δ * P₂ * (F - K) = (P₁ - P₂) - δ * K * P₂ ∧
+    (δ * P₂ * (F - K) = 0 ↔ K = F) := by
+  have hδF : δ * F = P₁ / P₂ - 1 := by
+    rw [hF]
+    field_simp [hδ]
+  have hP₁_div : P₁ / P₂ = 1 + δ * F := by linarith
+  have hP₁_eq : P₁ = P₂ * (1 + δ * F) := by
+    calc
+      P₁ = P₂ * (P₁ / P₂) := by field_simp [hP₂.ne.symm]
+      _ = P₂ * (1 + δ * F) := by rw [hP₁_div]
+  have h_eq : δ * P₂ * F = P₁ - P₂ := by linarith
+  have h_part2 : δ * P₂ * (F - K) = (P₁ - P₂) - δ * K * P₂ := by
+    calc
+      δ * P₂ * (F - K) = (δ * P₂ * F) - (δ * P₂ * K) := by ring
+      _ = (P₁ - P₂) - (δ * P₂ * K) := by rw [h_eq]
+      _ = (P₁ - P₂) - δ * K * P₂ := by ring
+  have h_part3 : (δ * P₂ * (F - K) = 0 ↔ K = F) := by
+    have h_nonzero : δ * P₂ ≠ 0 := mul_ne_zero hδ (by linarith)
+    constructor
+    · intro h
+      rcases eq_zero_or_eq_zero_of_mul_eq_zero h with (hδP₂ | hFK)
+      · exfalso; exact h_nonzero hδP₂
+      · linarith
+    · intro h; rw [h]; ring
+  exact And.intro hP₁_eq (And.intro h_part2 h_part3)
+
+end MathFin

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -3640,6 +3640,27 @@
           "upstream": "Yosuke Ito, AFP Actuarial Mathematics (Survival_Model), BSD — consulted as a source, cited"
         }
       }
+    },
+    {
+      "id": "mf-fi-fra",
+      "name": "Forward-Rate Agreement: Value and Fair Simple Forward Rate",
+      "description": "For zero-coupon discount factors P1=P(0,T1), P2=P(0,T2) (P2>0, accrual delta != 0) and the simple forward rate F=(P1/P2-1)/delta: F is the no-arbitrage rate P1=P2*(1+delta*F), the FRA value delta*P2*(F-K) equals the floating leg minus the fixed leg (P1-P2)-delta*K*P2, and it vanishes exactly at the fair rate K=F.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.FixedIncome.FRA\n\nopen MathFin\n\n/-- FRA value and fair simple forward rate: no-arbitrage rate, value as\n    floating-minus-fixed leg, and zero value exactly at K = F. -/\ntheorem mf_fi_fra {P₁ P₂ δ K F : ℝ} (hP₂ : 0 < P₂) (hδ : δ ≠ 0)\n    (hF : F = (P₁ / P₂ - 1) / δ) :\n    P₁ = P₂ * (1 + δ * F) ∧\n    δ * P₂ * (F - K) = (P₁ - P₂) - δ * K * P₂ ∧\n    (δ * P₂ * (F - K) = 0 ↔ K = F) :=\n  MathFin.fra_value_and_fair_rate hP₂ hδ hF\n"
+      },
+      "metadata": {
+        "chapter": 0,
+        "reference": "Forward-rate agreement / simple forward rate (Brigo–Mercurio, Bjork)",
+        "difficulty": "good-first",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/FixedIncome/FRA.lean (field_simp/ring over discount factors). Re-export from MathFin. Axioms-clean.",
+        "provenance": {
+          "source": "leanstral-autoform",
+          "model": "labs-leanstral-1-5",
+          "issue": 67
+        }
+      }
     }
   ]
 }

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 326 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 312 delivery-ready (full + library-wrapper).
+  scope: 327 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 313 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -46,7 +46,7 @@ automation:
         - labs-leanstral-1-5
       framework: "mathfin-foundry: probe / vibe <-> lean-lsp-mcp"
       tool_setup: token-paced GitHub Actions pipeline; on a pass it opens a ready-for-review PR on formal-mathfin that a human reviews (8-lens values panel) and merges
-      prompting_notes: 0 Leanstral-scouted proof(s) merged
+      prompting_notes: "1 Leanstral-scouted proof(s) merged (closing #67)"
     - method: own design, external source consulted (cited)
       models: []
       framework: Lean 4 + Mathlib, this library's conventions; an Isabelle/HOL AFP entry consulted as a source for the classical result set
@@ -105,9 +105,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 227 statements
+      lean: 228 statements
       module: benchmarks/mathematical_finance.json
-      status: full 226 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 227 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1193,6 +1193,13 @@
       "input_hash": "49a94be75bf5932b0296759114dae375add20f210f4db71845b697c543e97ef2",
       "verified_at_commit": "bfa3834"
     },
+    "mf-fi-fra": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-12",
+      "elapsed_s": 7.7,
+      "input_hash": "7e2443a9d046ac3867cb3855c570919c4bbe90be9375b5a8d5f8cd6035822141",
+      "verified_at_commit": "unknown"
+    },
     "mf-first-to-default-spread": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-07-11",


### PR DESCRIPTION
this pr was produced by the autoform pipeline (leanstral labs-leanstral-1-5), then assembled and validated green in ci. closes #67.

what it adds:
- `MathFin/FixedIncome/FRA.lean` — the proof (axioms-clean; the probe's axiom guard passed).
- a re-export entry in `benchmarks/mathematical_finance.json`.
- regenerated `MathFin/AxiomAuditGen.lean` + `formalization.yaml`.

provenance: leanstral, run tag `pipeline-20260712`, ~13777 tokens.

review checklist (8-lens, before merge):
- [ ] the statement faithfully formalizes issue #67 (no vacuity, no weaker restatement).
- [ ] the proof is idiomatic and consumes existing lemmas, not a wrapper.
- [ ] ledger row present (run `ledger verify` if ci is red on it).
- [ ] axioms clean; no slop.