### PR TITLE
fix(daemon): bound each lean elaboration so a spinning tactic can't wedge the repl

### DIFF
--- a/tests/test_lean_backend.py
+++ b/tests/test_lean_backend.py
@@ -1,0 +1,58 @@
+"""Unit tests for the daemon's Lean elaboration wrapper (`LeanBackend.run_raw`).
+
+These use a FAKE lean-interact server — no Lean process is booted — so they run
+on the host with zero memory cost (the memory doctrine is about live Lean envs).
+`run_raw` imports `Command` from lean_interact, so the module must be importable;
+skip cleanly if it is not (e.g. a CI pytest job without the extra installed).
+"""
+
+import pytest
+
+pytest.importorskip("lean_interact")  # run_raw does `from lean_interact import Command`
+
+from tools.verify.lean_backend import LeanBackend, _ELAB_TIMEOUT_S
+
+
+class _FakeServer:
+    """Records the kwargs each `.run` call receives; behaviour is injected."""
+
+    def __init__(self, behavior):
+        self._behavior = behavior
+        self.calls: list[dict] = []
+
+    def run(self, request, *, timeout=None, **kw):
+        self.calls.append({"timeout": timeout})
+        return self._behavior(request, timeout)
+
+
+def _backend_with(server) -> LeanBackend:
+    # bypass __init__ (which would want a real project) — run_raw needs only
+    # `_server` set; `_ensure_server` early-returns when it is not None.
+    b = LeanBackend.__new__(LeanBackend)
+    b._server = server
+    return b
+
+
+def test_run_raw_bounds_each_elaboration_with_a_finite_timeout():
+    # the root cause of the daemon wedging forever: run() was called with no
+    # timeout (lean-interact's DEFAULT_TIMEOUT is None → the socket read blocks
+    # indefinitely on a spinning tactic). run_raw MUST pass a finite timeout.
+    srv = _FakeServer(lambda req, timeout: "RESPONSE")
+    out = _backend_with(srv).run_raw("import Mathlib\n#check 1")
+    assert out == "RESPONSE"
+    assert srv.calls[0]["timeout"] == _ELAB_TIMEOUT_S
+    assert _ELAB_TIMEOUT_S is not None and _ELAB_TIMEOUT_S > 0
+
+
+def test_run_raw_timeout_surfaces_cleanly_and_does_not_retry():
+    # a spinning elaboration: lean-interact kills the REPL and raises TimeoutError.
+    # run_raw must NOT retry (re-running the same code just spins again) and must
+    # surface a clear failure the daemon can return to the client.
+    def spin(req, timeout):
+        raise TimeoutError(
+            f"The Lean server did not respond in time (timeout={timeout}) and is now killed.")
+
+    srv = _FakeServer(spin)
+    with pytest.raises(RuntimeError, match="timed out"):
+        _backend_with(srv).run_raw("theorem x : False := by nlinarith")
+    assert len(srv.calls) == 1  # exactly one attempt — no retry-spin

--- a/tools/verify/lean_backend.py
+++ b/tools/verify/lean_backend.py
@@ -35,6 +35,16 @@ _SERVER_DEATH_MARKERS = (
     "not enough memory",
 )
 
+# Per-elaboration wall-clock bound. lean-interact's own DEFAULT_TIMEOUT is None
+# (an unbounded `t.join(None)` on the REPL read), so WITHOUT this a single spinning
+# tactic — e.g. a leanstral faithfulness-gate candidate running `nlinarith` on an
+# unprovable `⊢ False` — wedges the daemon forever (the REPL never replies, the read
+# blocks, the client only ever hits its own socket timeout). Bounding each call lets
+# lean-interact kill the stuck REPL and respawn a fresh one. Generous (a real proof
+# elaborates in well under a minute); override via LEAN_ELAB_TIMEOUT for the rare
+# heavy file.
+_ELAB_TIMEOUT_S = float(os.environ.get("LEAN_ELAB_TIMEOUT", "180"))
+
 
 def _looks_like_server_death(exc: Exception) -> bool:
     """Heuristic: did this exception come from the REPL subprocess dying
@@ -230,7 +240,21 @@ class LeanBackend:
         last_exc: Exception | None = None
         for attempt in range(attempts):
             try:
-                return self._server.run(Command(cmd=code))
+                return self._server.run(Command(cmd=code), timeout=_ELAB_TIMEOUT_S)
+            except TimeoutError as e:
+                # A bounded elaboration timed out: lean-interact has already KILLED
+                # the REPL process (the spinning tactic is gone). Do NOT retry — the
+                # same code just spins again. The next request lazily respawns a
+                # fresh REPL (AutoLeanServer restarts a dead server on its next run),
+                # so surface this as an elaboration failure the daemon returns to the
+                # client, which then treats it as a failed check and moves on.
+                logger.warning(
+                    "Lean elaboration timed out after %ss — REPL killed; "
+                    "next request respawns a fresh one", _ELAB_TIMEOUT_S,
+                )
+                raise RuntimeError(
+                    f"elaboration timed out after {_ELAB_TIMEOUT_S}s (REPL killed)"
+                ) from e
             except Exception as e:  # noqa: BLE001 — classify, then recover or re-raise
                 last_exc = e
                 if not _looks_like_server_death(e):


### PR DESCRIPTION
## what

the lean-repl daemon had no elaboration timeout. lean-interact's `DEFAULT_TIMEOUT` is
`None`, and `run_raw` called `server.run(Command(...))` with no `timeout`, so the repl
read blocked forever on a spinning tactic. one leanstral autoformalizer faithfulness-gate
candidate running `nlinarith` on an unprovable false goal never replied, wedging the
daemon (it holds `_lock`) until the client's own socket timeout fired. this was the real
cause of the autoformalizer runs "hanging", previously mis-filed as free-tier throttle / OOM.

(this is a distinct failure mode from a repl *crash* — a crash is already handled by the
pre-existing `_looks_like_server_death` self-heal, which respawns and retries. this fixes
the *hang*, which nothing caught.)

## fix

`run_raw` now passes `timeout=LEAN_ELAB_TIMEOUT` (default 180s). lean-interact kills the
stuck repl on timeout and the next request respawns a fresh one. a timeout surfaces as a
clean elaboration failure and is not retried (the same code just re-spins). a real proof
elaborates in well under a minute, so 180s is invisible to legitimate use; override via
`LEAN_ELAB_TIMEOUT` for a heavy file.

## test

`tests/test_lean_backend.py`, with a fake server (no lean boot, importorskip-guarded):
`run_raw` passes a finite timeout, and a `TimeoutError` surfaces as a single non-retried
failure. full suite green (27 passed).

## deploy note

the CI pipeline daemon runs the baked image, and `tools/` is excluded from
`publish-image.yml`'s trigger paths, so this reaches CI via a manual image republish
(triggered from this branch).
