### PR TITLE
autoform: InterestRateSwap (closes #66)

### DIFF
--- a/MathFin.lean
+++ b/MathFin.lean
@@ -436,3 +436,4 @@ import MathFin.Actuarial.SurvivalModel
 -- cm-thm-4.3.7; its sibling cm-thm-4.3.9 works only because
 -- Foundations/LpContinuousMartingaleConvergence imports Degenne's DoobLp).
 import BrownianMotion.StochasticIntegral.LocalMartingale
+import MathFin.FixedIncome.InterestRateSwap

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (279 constants). Scope: proof-position MathFin names only —
+  corpus (280 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -697,6 +697,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.nthMoment_terminal' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.nthMoment_terminal
+
+/-- info: 'MathFin.payerSwapValue_zcb_eq_zero_iff' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.payerSwapValue_zcb_eq_zero_iff
 
 /-- info: 'MathFin.portfolioVarN_covariance_nonneg' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.portfolioVarN_covariance_nonneg

--- a/MathFin/FixedIncome/InterestRateSwap.lean
+++ b/MathFin/FixedIncome/InterestRateSwap.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 Raphael Coelho. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Coelho
+-/
+module
+
+public import Mathlib
+public import MathFin.FixedIncome.ZCB
+
+-- pointers: MathFin/FixedIncome/ZCB.lean
+-- main-module: MathFin/FixedIncome/InterestRateSwap.lean
+-- benchmark: benchmarks/mathematical_finance.json
+-- benchmark-id: mf-fixedincome-swap
+-- source-issue: 66
+-- new-defs: annuity, payerSwapValue, parSwapRate
+
+/-!
+Vanilla interest-rate swap: the annuity, the payer-swap value, the par swap
+rate, and the par identity — the swap is worth zero iff the fixed rate is the
+par rate. The identity is pure annuity algebra, proved for any nonzero annuity
+and instantiated on the `zcb` curve, where positivity of the discount factors
+is a theorem (`zcb_pos`), not an assumption. The annuity here is the numéraire
+`A` consumed by `blackPayerSwaption` in `MathFin/Futures/Black76.lean`.
+-/
+
+set_option autoImplicit false
+
+@[expose] public section
+
+namespace MathFin
+
+/-- Annuity (fixed-leg PV01) of a payment schedule `s` with daycount fraction
+`δ` and discount factors `P`: `A = δ · ∑ i ∈ s, P i`. -/
+def annuity {ι : Type*} (δ : ℝ) (P : ι → ℝ) (s : Finset ι) : ℝ := δ * ∑ i ∈ s, P i
+
+/-- Payer-swap value over given discount factors: the floating leg `P₀ − Pₙ`
+minus the fixed leg `K · A`, `A` the annuity of the fixed schedule. -/
+def payerSwapValue (P0 Pn K A : ℝ) : ℝ := P0 - Pn - K * A
+
+/-- Par swap rate: the fixed rate that makes the payer swap worth zero,
+`S = (P₀ − Pₙ) / A`. -/
+noncomputable def parSwapRate (P0 Pn A : ℝ) : ℝ := (P0 - Pn) / A
+
+/-- The annuity of a nonempty schedule with positive daycount and positive
+discount factors is positive. -/
+theorem annuity_pos {ι : Type*} {δ : ℝ} {P : ι → ℝ} {s : Finset ι} (hδ : 0 < δ)
+    (hP : ∀ i ∈ s, 0 < P i) (hs : s.Nonempty) : 0 < annuity δ P s :=
+  mul_pos hδ (Finset.sum_pos hP hs)
+
+/-- **The par identity**: a payer swap is worth zero iff its fixed rate is the
+par swap rate — pure algebra, valid for any nonzero annuity. -/
+theorem payerSwapValue_eq_zero_iff (P0 Pn K : ℝ) {A : ℝ} (hA : A ≠ 0) :
+    payerSwapValue P0 Pn K A = 0 ↔ K = parSwapRate P0 Pn A := by
+  show P0 - Pn - K * A = 0 ↔ K = (P0 - Pn) / A
+  rw [sub_eq_zero, eq_div_iff hA]
+  exact eq_comm
+
+/-- The par identity on the `zcb` curve: a positive daycount and a nonempty
+payment schedule make the annuity positive (`zcb` is a positive exponential),
+so no positivity hypotheses are needed. -/
+theorem payerSwapValue_zcb_eq_zero_iff {ι : Type*} (r δ K T0 Tn : ℝ) (T : ι → ℝ)
+    (s : Finset ι) (hδ : 0 < δ) (hs : s.Nonempty) :
+    payerSwapValue (zcb r 0 T0) (zcb r 0 Tn) K (annuity δ (fun i ↦ zcb r 0 (T i)) s) = 0 ↔
+      K = parSwapRate (zcb r 0 T0) (zcb r 0 Tn) (annuity δ (fun i ↦ zcb r 0 (T i)) s) :=
+  payerSwapValue_eq_zero_iff _ _ _
+    (annuity_pos hδ (fun i _ ↦ zcb_pos r 0 (T i)) hs).ne'
+
+end MathFin

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -3720,6 +3720,35 @@
         "formalization_status": "full",
         "formalization_scope": "Full formal proof re-exported from MathFin. Verifies A(t)=½·D₊^{-½}·matrixRiccatiCoeff·D₊^{-½} solves the market-making matrix Riccati A'=2·A·D₊·A−(γ/2)·cov, with D₊=diagonal d positive and Â Hermitian satisfying Â·Â=γ·(D₊^{½}·cov·D₊^{½}) — Â enters by this defining relation (the matrix-square-root construction of Â is out of scope, so the verified content is the change of variables). The optimal-control substrate and the B/C coefficients are out of scope. Axioms-clean."
       }
+    },
+    {
+      "id": "mf-fixedincome-swap",
+      "name": "Formalize the vanilla interest-rate swap value and par swap rate S = (P(0,T₀)−P(0,Tₙ))/(δ·Σ P(0,Tᵢ))",
+      "description": "Vanilla interest-rate swap: annuity, payer-swap value, par swap rate, and the par identity over the zcb curve.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.FixedIncome.InterestRateSwap\n\nopen MathFin\n\n/-- Vanilla interest-rate swap par identity on the zcb curve: with a positive daycount and a nonempty payment schedule, the payer swap is worth zero iff the fixed rate is the par swap rate. -/\ntheorem mf_fixedincome_swap {ι : Type*} (r δ K T0 Tn : ℝ) (T : ι → ℝ) (s : Finset ι)\n    (hδ : 0 < δ) (hs : s.Nonempty) :\n    payerSwapValue (zcb r 0 T0) (zcb r 0 Tn) K (annuity δ (fun i ↦ zcb r 0 (T i)) s) = 0 ↔\n      K = parSwapRate (zcb r 0 T0) (zcb r 0 Tn) (annuity δ (fun i ↦ zcb r 0 (T i)) s) :=\n  MathFin.payerSwapValue_zcb_eq_zero_iff r δ K T0 Tn T s hδ hs\n"
+      },
+      "metadata": {
+        "chapter": 0,
+        "reference": "Formalize the vanilla interest-rate swap value and par swap rate S = (P(0,T₀)−P(0,Tₙ))/(δ·Σ P(0,Tᵢ))",
+        "difficulty": "small",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/FixedIncome/InterestRateSwap.lean (magistral-drafted statement, leanstral proof, human-refined at review). The par identity payerSwapValue = 0 ↔ K = parSwapRate is proved abstractly for any nonzero annuity (payerSwapValue_eq_zero_iff) and instantiated on the zcb curve with positivity discharged by zcb_pos + annuity_pos rather than assumed. Re-export from MathFin. Axioms-clean. Introduces definitions: annuity, payerSwapValue, parSwapRate (new-defs review class).",
+        "provenance": {
+          "statement_source": "magistral-autoform",
+          "statement_model": "magistral-medium",
+          "source": "leanstral-autoform",
+          "model": "labs-leanstral-1-5",
+          "issue": 66,
+          "new_defs": [
+            "annuity",
+            "payerSwapValue",
+            "parSwapRate"
+          ],
+          "refined": "statement generalized at review: abstract A ≠ 0 core + zcb corollary; lint-clean names + docstrings; unused hypotheses and imports removed"
+        }
+      }
     }
   ]
 }

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -26,7 +26,20 @@ Report `reduced_core` and `placeholder` separately. **Spec-with-axiomatized-conc
 
 ## Current Audit
 
-> **Live status (2026-07-18, jump calculus — the Itô–Lévy integral CLM):** corpus **339**,
+> **Live status (2026-07-18, first refined autoform PR — the vanilla swap par identity):** corpus
+> **340**, **308 full + 18 wrappers = 326/340 delivery-ready**, 14 reduced cores, 0 placeholders.
+> `mf-fixedincome-swap` (`FixedIncome/InterestRateSwap`, closes #66; the first autoform-pipeline PR
+> to land — Leanstral-drafted and -proved, human-refined at review): the **par identity**
+> `payerSwapValue P₀ Pₙ K A = 0 ↔ K = parSwapRate P₀ Pₙ A`, proved abstractly for any nonzero
+> annuity (`payerSwapValue_eq_zero_iff`, a two-rewrite `sub_eq_zero`/`eq_div_iff` certificate) and
+> instantiated on the `zcb` curve (`payerSwapValue_zcb_eq_zero_iff`) where positivity is discharged
+> by `zcb_pos` + `annuity_pos` — assumed nowhere. New defs `annuity` (`A = δ·∑ P(0,Tᵢ)` — the
+> numéraire slot `blackPayerSwaption` consumes), `payerSwapValue`, `parSwapRate`. The refinery diff
+> vs the drafted statement: derivable positivity hypothesis dropped, member-witness binders replaced
+> by `s.Nonempty`, flat-curve specialization demoted from theorem to corollary, snake_case def names
+> and missing docstrings fixed (the classes the pipeline now gates itself).
+>
+> **Prior (2026-07-18, jump calculus — the Itô–Lévy integral CLM):** corpus **339**,
 > **307 full + 18 wrappers = 325/339 delivery-ready**, 14 reduced cores, 0 placeholders. The
 > **jump/Lévy axis** now carries the compensated-Poisson (Itô–Lévy) stochastic integral all the way
 > to a continuous linear operator and its `L²` isometry — **`cgarryZA/LevyStochCalc`'s (Apache-2.0,

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 339 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 325 delivery-ready (full + library-wrapper).
+  scope: 340 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 326 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -47,7 +47,7 @@ automation:
         - labs-leanstral-1-5
       framework: "mathfin-foundry: probe / vibe <-> lean-lsp-mcp"
       tool_setup: token-paced GitHub Actions pipeline; Magistral specifies the statement, Leanstral formalizes + proves it. A cheap autop tactic-probe may scout-close a goal Leanstral missed; those open as DRAFT PRs (labeled scout-proof, attributed to the tactic, refactored before merge, never silently merged). On a Leanstral pass it opens a ready-for-review PR on formal-mathfin that a human reviews (8-lens values panel) and merges
-      prompting_notes: "0 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral)"
+      prompting_notes: "1 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66)"
     - method: own design, external source consulted (cited)
       models: []
       framework: Lean 4 + Mathlib, this library's conventions; an Isabelle/HOL AFP entry consulted as a source for the classical result set
@@ -106,9 +106,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 232 statements
+      lean: 233 statements
       module: benchmarks/mathematical_finance.json
-      status: full 231 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 232 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1228,6 +1228,13 @@
       "input_hash": "4d09105bf5baaf1fe32d29ef633688383a51d351f0953bcf76809ee971b62b23",
       "verified_at_commit": "bfa3834"
     },
+    "mf-fixedincome-swap": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-18",
+      "elapsed_s": 4.8,
+      "input_hash": "5a885c8d41fd0ecdf2f340d086c1098fa1d39e09d783d1e28971205b5c15b60d",
+      "verified_at_commit": "unknown"
+    },
     "mf-forward-measure-spot": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-07-11",


### PR DESCRIPTION
this pr was produced by the autoform pipeline (leanstral labs-leanstral-1-5), then human-refined at review (the 8-lens refinery pass). closes #66.

what it adds:
- `MathFin/FixedIncome/InterestRateSwap.lean` — `annuity` (the numéraire slot `blackPayerSwaption` consumes), `payerSwapValue`, `parSwapRate`, `annuity_pos`, and the par identity `payerSwapValue = 0 ↔ K = parSwapRate`, proved abstractly for any nonzero annuity and instantiated on the `zcb` curve. axioms-clean.
- a re-export entry `mf-fixedincome-swap` in `benchmarks/mathematical_finance.json`.
- regenerated `MathFin/AxiomAuditGen.lean` (280 guards) + `formalization.yaml` + ledger row + coverage journal entry.

refinery diff vs the drafted statement (2026-07-18):
- statement generalized: the identity is pure annuity algebra, so the core theorem takes `A ≠ 0` on abstract reals; the zcb version is a corollary where positivity is discharged by `zcb_pos` + `annuity_pos` — the drafted version assumed derivable positivity and forced the reset date into the annuity sum via a member-witness binder (`hT0 : T_0 ∈ s`), which the standard payment-schedule convention cannot instantiate. now `s.Nonempty`.
- unused hypothesis `hTn` dropped; unused `YieldCurve`/`Black76` imports dropped.
- def names to lowerCamelCase + docstrings (the `lake lint` classes that had this pr red).
- proof golfed to its certificate: `sub_eq_zero` then `eq_div_iff` (was set/constructor/field_simp/linarith).

the drafter classes found here are now gated in the pipeline itself (mathfin-foundry: draft-time lint repair, gate-time unused-hypothesis strip + import trim, full `lake lint` + python gates before any pr opens).

provenance: leanstral (statement draft + original proof), run tag `pipeline-20260717-191900`; human refinery at review — scout, not author, as designed.