### PR TITLE
autoform: ActuarialInsurance (closes #85)

### DIFF
--- a/MathFin.lean
+++ b/MathFin.lean
@@ -437,3 +437,4 @@ import MathFin.Actuarial.SurvivalModel
 -- Foundations/LpContinuousMartingaleConvergence imports Degenne's DoobLp).
 import BrownianMotion.StochasticIntegral.LocalMartingale
 import MathFin.FixedIncome.InterestRateSwap
+import MathFin.Actuarial.ActuarialInsurance

--- a/MathFin/Actuarial/ActuarialInsurance.lean
+++ b/MathFin/Actuarial/ActuarialInsurance.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 Raphael Coelho. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Coelho
+-/
+module
+
+public import Mathlib
+
+-- pointers: MathFin/Actuarial/Insurance.lean
+-- main-module: MathFin/Actuarial/ActuarialInsurance.lean
+-- benchmark: benchmarks/mathematical_finance.json
+-- benchmark-id: mf-insurance-premium-principles
+-- source-issue: 85
+-- new-defs: expectedValuePremium, variancePremium, stdDevPremium
+
+/-!
+Classical loaded premium principles — expected-value `(1 + θ)·μ`, variance
+`μ + α·σ²`, standard-deviation `μ + β·σ` — and their nonnegative-loading
+bound: each principle prices at or above the pure premium (the mean loss).
+The loadings are the safety margins on top of the net premium of
+`MathFin/Actuarial/Insurance.lean`.
+-/
+
+set_option autoImplicit false
+
+@[expose] public section
+
+namespace MathFin
+
+/-- Expected-value premium principle with loading `θ`: `(1 + θ) · μ`. -/
+def expectedValuePremium (θ μ : ℝ) : ℝ := (1 + θ) * μ
+
+/-- Variance premium principle with loading `α` on the variance `σ²`:
+`μ + α · σ²`. -/
+def variancePremium (α μ σ2 : ℝ) : ℝ := μ + α * σ2
+
+/-- Standard-deviation premium principle with loading `β`: `μ + β · σ`. -/
+def stdDevPremium (β μ σ : ℝ) : ℝ := μ + β * σ
+
+/-- A nonnegative loading prices at or above the mean: expected-value principle. -/
+theorem expectedValuePremium_ge_mean {θ μ : ℝ} (hθ : 0 ≤ θ) (hμ : 0 ≤ μ) :
+    expectedValuePremium θ μ ≥ μ :=
+  le_mul_of_one_le_left hμ (le_add_of_nonneg_right hθ)
+
+/-- A nonnegative loading prices at or above the mean: variance principle. -/
+theorem variancePremium_ge_mean {α σ2 : ℝ} (μ : ℝ) (hα : 0 ≤ α) (hσ2 : 0 ≤ σ2) :
+    variancePremium α μ σ2 ≥ μ :=
+  le_add_of_nonneg_right (mul_nonneg hα hσ2)
+
+/-- A nonnegative loading prices at or above the mean: standard-deviation
+principle. -/
+theorem stdDevPremium_ge_mean {β σ : ℝ} (μ : ℝ) (hβ : 0 ≤ β) (hσ : 0 ≤ σ) :
+    stdDevPremium β μ σ ≥ μ :=
+  le_add_of_nonneg_right (mul_nonneg hβ hσ)
+
+/-- All three classical premium principles with nonnegative loadings price at
+or above the pure premium. -/
+theorem premium_ge_mean (μ σ2 σ θ α β : ℝ) (hμ : 0 ≤ μ) (hσ2 : 0 ≤ σ2)
+    (hσ : 0 ≤ σ) (hθ : 0 ≤ θ) (hα : 0 ≤ α) (hβ : 0 ≤ β) :
+    expectedValuePremium θ μ ≥ μ ∧ variancePremium α μ σ2 ≥ μ ∧
+      stdDevPremium β μ σ ≥ μ :=
+  ⟨expectedValuePremium_ge_mean hθ hμ, variancePremium_ge_mean μ hα hσ2,
+    stdDevPremium_ge_mean μ hβ hσ⟩
+
+end MathFin

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (280 constants). Scope: proof-position MathFin names only —
+  corpus (281 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -727,6 +727,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.powerForward_price' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.powerForward_price
+
+/-- info: 'MathFin.premium_ge_mean' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.premium_ge_mean
 
 /-- info: 'MathFin.putCall_parity_from_no_arbitrage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.putCall_parity_from_no_arbitrage

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -3749,6 +3749,35 @@
           "refined": "statement generalized at review: abstract A ≠ 0 core + zcb corollary; lint-clean names + docstrings; unused hypotheses and imports removed"
         }
       }
+    },
+    {
+      "id": "mf-insurance-premium-principles",
+      "name": "Formalize the classical loaded premium principles (expected-value, variance, standard-deviation) and their nonnegative-loading bounds",
+      "description": "Classical loaded premium principles and their nonnegative-loading bounds: each prices at or above the pure premium.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Actuarial.ActuarialInsurance\n\nopen MathFin\n\n/-- The three classical loaded premium principles with nonnegative loadings price at or above the pure premium (the mean loss). -/\ntheorem mf_insurance_premium_principles (μ σ2 σ θ α β : ℝ) (hμ : 0 ≤ μ) (hσ2 : 0 ≤ σ2)\n    (hσ : 0 ≤ σ) (hθ : 0 ≤ θ) (hα : 0 ≤ α) (hβ : 0 ≤ β) :\n    expectedValuePremium θ μ ≥ μ ∧ variancePremium α μ σ2 ≥ μ ∧ stdDevPremium β μ σ ≥ μ :=\n  MathFin.premium_ge_mean μ σ2 σ θ α β hμ hσ2 hσ hθ hα hβ\n"
+      },
+      "metadata": {
+        "chapter": 0,
+        "reference": "Formalize the classical loaded premium principles (expected-value, variance, standard-deviation) and their nonnegative-loading bounds",
+        "difficulty": "small",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/Actuarial/ActuarialInsurance.lean (magistral-drafted statement, leanstral proof, human-refined at review). Each principle carries its own named bound (expectedValuePremium_ge_mean, variancePremium_ge_mean, stdDevPremium_ge_mean — one-term mul_nonneg certificates); premium_ge_mean bundles them. Re-export from MathFin. Axioms-clean. Introduces definitions: expectedValuePremium, variancePremium, stdDevPremium (new-defs review class).",
+        "provenance": {
+          "statement_source": "magistral-autoform",
+          "statement_model": "magistral-medium",
+          "source": "leanstral-autoform",
+          "model": "labs-leanstral-1-5",
+          "issue": 85,
+          "new_defs": [
+            "expectedValuePremium",
+            "variancePremium",
+            "stdDevPremium"
+          ],
+          "refined": "signature-bound def arguments + docstrings (docBlame); unused hσ_eq hypothesis and unused Insurance import removed; per-principle lemmas extracted, bundle derived from them"
+        }
+      }
     }
   ]
 }

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -26,7 +26,22 @@ Report `reduced_core` and `placeholder` separately. **Spec-with-axiomatized-conc
 
 ## Current Audit
 
-> **Live status (2026-07-18, first refined autoform PR — the vanilla swap par identity):** corpus
+> **Live status (2026-07-18, second refined autoform PR — loaded premium principles):** corpus
+> **341**, **309 full + 18 wrappers = 327/341 delivery-ready**, 14 reduced cores, 0 placeholders.
+> `mf-insurance-premium-principles` (`Actuarial/ActuarialInsurance`, closes #85; the second
+> autoform-pipeline PR — the generalization run's output, Leanstral-drafted and -proved,
+> human-refined at review): the three classical **loaded premium principles** — expected-value
+> `(1+θ)·μ`, variance `μ + α·σ²`, standard-deviation `μ + β·σ` — each with its own named
+> nonnegative-loading bound (`expectedValuePremium_ge_mean` via `le_mul_of_one_le_left`,
+> `variancePremium_ge_mean` / `stdDevPremium_ge_mean` via one-term `mul_nonneg` certificates), and
+> the bundle `premium_ge_mean` assembled from them. The loadings sit on top of the net premium of
+> `Actuarial/Insurance.lean` (prose seam; the net-premium algebra there is Mathlib's `eq_div_iff`
+> consumed directly, same certificate family as the swap par identity). Refinery diff vs the draft:
+> signature-bound def arguments + docstrings (the `docBlame` red), the never-used coupling
+> hypothesis `hσ_eq : σ = √σ²` dropped, the unused `Insurance` import dropped, per-principle lemmas
+> extracted so the bundle is a `⟨…, …, …⟩` of certificates rather than three `nlinarith` calls.
+>
+> **Prior (2026-07-18, first refined autoform PR — the vanilla swap par identity):** corpus
 > **340**, **308 full + 18 wrappers = 326/340 delivery-ready**, 14 reduced cores, 0 placeholders.
 > `mf-fixedincome-swap` (`FixedIncome/InterestRateSwap`, closes #66; the first autoform-pipeline PR
 > to land — Leanstral-drafted and -proved, human-refined at review): the **par identity**

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 340 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 326 delivery-ready (full + library-wrapper).
+  scope: 341 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 327 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -47,7 +47,7 @@ automation:
         - labs-leanstral-1-5
       framework: "mathfin-foundry: probe / vibe <-> lean-lsp-mcp"
       tool_setup: token-paced GitHub Actions pipeline; Magistral specifies the statement, Leanstral formalizes + proves it. A cheap autop tactic-probe may scout-close a goal Leanstral missed; those open as DRAFT PRs (labeled scout-proof, attributed to the tactic, refactored before merge, never silently merged). On a Leanstral pass it opens a ready-for-review PR on formal-mathfin that a human reviews (8-lens values panel) and merges
-      prompting_notes: "1 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66)"
+      prompting_notes: "2 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85)"
     - method: own design, external source consulted (cited)
       models: []
       framework: Lean 4 + Mathlib, this library's conventions; an Isabelle/HOL AFP entry consulted as a source for the classical result set
@@ -106,9 +106,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 233 statements
+      lean: 234 statements
       module: benchmarks/mathematical_finance.json
-      status: full 232 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 233 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1473,6 +1473,13 @@
       "input_hash": "854b85e2bba65ee66575a3584c4198711341496a0e98b8a46e204bc7c1039329",
       "verified_at_commit": "4ca5e6d"
     },
+    "mf-insurance-premium-principles": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-18",
+      "elapsed_s": 3.7,
+      "input_hash": "c6576ab712d21ef7ec14885e128006dc0280cba345f385919e30ae728c1025c5",
+      "verified_at_commit": "unknown"
+    },
     "mf-integral-log-forward": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-07-11",


### PR DESCRIPTION
this pr was produced by the autoform pipeline (leanstral labs-leanstral-1-5) on the generalization run, then human-refined at review (the 8-lens refinery pass). closes #85.

what it adds:
- `MathFin/Actuarial/ActuarialInsurance.lean` — the three classical loaded premium principles (`expectedValuePremium`, `variancePremium`, `stdDevPremium`), each with its own named nonnegative-loading bound, and the bundle `premium_ge_mean` assembled from them. axioms-clean.
- a re-export entry `mf-insurance-premium-principles` in `benchmarks/mathematical_finance.json`.
- regenerated `MathFin/AxiomAuditGen.lean` (281 guards) + `formalization.yaml` + ledger row + coverage journal entry.

refinery diff vs the drafted statement (2026-07-18):
- defs rewritten to signature-bound arguments with docstrings (`def f (x : ℝ) : ℝ := …`, was `: ∀ (x : ℝ), ℝ := λ …` with no docstrings — the `docBlame` red on this pr).
- the never-used coupling hypothesis `hσ_eq : σ = Real.sqrt σ2` dropped (the strengthen-pass class, hand-applied here).
- the unused `MathFin.Actuarial.Insurance` import dropped (the import-trim class, hand-applied here); the net-premium seam is prose, not a dependency.
- per-principle lemmas extracted (`le_mul_of_one_le_left` / `mul_nonneg` one-term certificates); the bundle is `⟨…, …, …⟩` of them rather than three `dsimp; nlinarith` blocks.

the drafter classes found here are gated in the pipeline as of mathfin-foundry `a4f64f9`/`a5fc423`/`ef00b11` (draft-time lint repair, gate-time unused-hypothesis strip + import trim, full `lake lint` + python gates before any pr opens).

provenance: leanstral (statement draft + original proof), run tag `pipeline-20260717-214917`; human refinery at review — scout, not author, as designed.