### PR TITLE
feat(blackscholes): in-out barrier parity from the hit-event partition (closes #53)

### DIFF
--- a/MathFin.lean
+++ b/MathFin.lean
@@ -262,6 +262,7 @@ import MathFin.BlackScholes.Chooser
 import MathFin.BlackScholes.CappedCall
 import MathFin.BlackScholes.Spreads
 import MathFin.BlackScholes.Lookback
+import MathFin.BlackScholes.BarrierParity
 import MathFin.BlackScholes.PowerOption
 import MathFin.BlackScholes.BreedenLitzenberger
 import MathFin.BlackScholes.BisectionIV

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (281 constants). Scope: proof-position MathFin names only —
+  corpus (282 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -652,6 +652,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.kmvPD_eq_one_sub_survival_probability' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.kmvPD_eq_one_sub_survival_probability
+
+/-- info: 'MathFin.knockIn_add_knockOut_eq_vanilla' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.knockIn_add_knockOut_eq_vanilla
 
 /-- info: 'MathFin.log_forward_div_bsTerminal_eq' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.log_forward_div_bsTerminal_eq

--- a/MathFin/BlackScholes/BarrierParity.lean
+++ b/MathFin/BlackScholes/BarrierParity.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 Raphael Coelho. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Coelho
+-/
+module
+
+public import Mathlib
+
+/-!
+# Knock-in / knock-out barrier parity (in–out parity)
+
+A knock-**in** option pays the vanilla payoff `f` only if the underlying path
+hits the barrier during the option's life; the matching knock-**out** pays `f`
+only if it does *not*. The barrier-hit event `A` and its complement `Aᶜ`
+partition every path, so the two discounted expected payoffs add back to the
+vanilla price:
+
+`V_in + V_out = V_vanilla`.
+
+This needs **no** barrier density and no running-max law — it is a pure
+linearity-of-expectation identity, in the register of
+`BlackScholes/ChooserComposition.lean`'s `chooser_integral_decomp`: a pathwise
+payoff decomposition (`barrier_payoff_partition`) lifted through the integral.
+
+We first name the present-value functional the library had only ever written
+inline — `discountedValue D Q g = D · E_Q[g]` — so the barrier values are thin,
+honest specialisations of it and the parity reads as an identity about *values*.
+
+## Results
+
+* `discountedValue`: `D · E_Q[g]`, the discounted risk-neutral value functional.
+* `knockInValue` / `knockOutValue` / `vanillaValue`: the three barrier values.
+* `barrier_payoff_partition`: the pathwise split `𝟙_A·f + 𝟙_{Aᶜ}·f = f`.
+* `knockIn_add_knockOut_eq_vanilla`: in–out parity `V_in + V_out = V_vanilla`.
+-/
+
+@[expose] public section
+
+namespace MathFin
+
+open MeasureTheory
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω}
+
+/-- **Discounted risk-neutral value** of a payoff `g` under pricing measure `Q`
+and discount factor `D`: `D · E_Q[g]`. The present-value functional the pricing
+files had been spelling out inline; named here so in–out parity is an identity
+about values rather than raw integrals. -/
+noncomputable def discountedValue (D : ℝ) (Q : Measure Ω) (g : Ω → ℝ) : ℝ :=
+  D * ∫ ω, g ω ∂Q
+
+/-- **Knock-in value**: the option pays the payoff `f` only on the barrier-hit
+event `A`, so its value is the discounted expectation of `𝟙_A · f`. -/
+noncomputable def knockInValue (D : ℝ) (Q : Measure Ω) (A : Set Ω) (f : Ω → ℝ) : ℝ :=
+  discountedValue D Q (A.indicator f)
+
+/-- **Knock-out value**: the option pays `f` only off the barrier-hit event, i.e.
+on the complement `Aᶜ`, so its value is the discounted expectation of
+`𝟙_{Aᶜ} · f = (1 − 𝟙_A) · f`. -/
+noncomputable def knockOutValue (D : ℝ) (Q : Measure Ω) (A : Set Ω) (f : Ω → ℝ) : ℝ :=
+  discountedValue D Q (Aᶜ.indicator f)
+
+/-- **Vanilla value**: the discounted expected payoff `f`, paid on every path. -/
+noncomputable def vanillaValue (D : ℝ) (Q : Measure Ω) (f : Ω → ℝ) : ℝ :=
+  discountedValue D Q f
+
+/-- **Barrier payoff partition** (pathwise): the knock-in payoff `𝟙_A · f` and the
+knock-out payoff `𝟙_{Aᶜ} · f` sum to the vanilla payoff `f` on every path — each
+path either hits the barrier (`ω ∈ A`) or does not (`ω ∈ Aᶜ`), and contributes
+`f ω` to exactly one leg. -/
+theorem barrier_payoff_partition (A : Set Ω) (f : Ω → ℝ) :
+    A.indicator f + Aᶜ.indicator f = f :=
+  Set.indicator_self_add_compl A f
+
+/-- **In–out barrier parity**: `V_in + V_out = V_vanilla`. The barrier-hit event
+`A` and its complement partition the paths (`barrier_payoff_partition`), so the
+discounted expected payoffs add to the vanilla price. Pure linearity of the
+integral — no barrier density required. -/
+theorem knockIn_add_knockOut_eq_vanilla
+    (D : ℝ) (Q : Measure Ω) (A : Set Ω) (f : Ω → ℝ)
+    (hA : MeasurableSet A) (hf : Integrable f Q) :
+    knockInValue D Q A f + knockOutValue D Q A f = vanillaValue D Q f := by
+  unfold knockInValue knockOutValue vanillaValue discountedValue
+  rw [← mul_add, integral_indicator hA, integral_indicator hA.compl,
+    integral_add_compl hA hf]
+
+end MathFin

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -2466,6 +2466,22 @@
       }
     },
     {
+      "id": "mf-barrier-inout-parity",
+      "name": "Knock-in / Knock-out Barrier Parity (in-out parity)",
+      "description": "V_in + V_out = V_vanilla: the barrier-hit event A and its complement partition every path, so the discounted expected payoffs add to the vanilla price. Pure linearity of expectation; needs no barrier density.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.BlackScholes.BarrierParity\n\nopen MeasureTheory\nopen MathFin\n\ntheorem knockIn_add_knockOut_eq_vanilla_thm {Ω : Type*} {mΩ : MeasurableSpace Ω}\n    (D : ℝ) (Q : Measure Ω) (A : Set Ω) (f : Ω → ℝ)\n    (hA : MeasurableSet A) (hf : Integrable f Q) :\n    knockInValue D Q A f + knockOutValue D Q A f = vanillaValue D Q f :=\n  MathFin.knockIn_add_knockOut_eq_vanilla D Q A f hA hf\n"
+      },
+      "metadata": {
+        "chapter": 14,
+        "reference": "In-out barrier parity (Hull, barrier options)",
+        "difficulty": "intermediate",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof. Re-export from MathFin. Axioms-clean."
+      }
+    },
+    {
       "id": "mf-capped-call-bull-spread",
       "name": "Capped Call equals Bull Call Spread",
       "description": "min(max(S - K₁, 0), K₂ - K₁) = max(S - K₁, 0) - max(S - K₂, 0). Pure pointwise algebra via case split on S.",

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -26,7 +26,22 @@ Report `reduced_core` and `placeholder` separately. **Spec-with-axiomatized-conc
 
 ## Current Audit
 
-> **Live status (2026-07-18, second refined autoform PR — loaded premium principles):** corpus
+> **Live status (2026-07-18, in-out barrier parity — closes #53):** corpus
+> **342**, **310 full + 18 wrappers = 328/342 delivery-ready**, 14 reduced cores, 0 placeholders.
+> `mf-barrier-inout-parity` (`BlackScholes/BarrierParity`, closes #53): knock-in / knock-out
+> **in-out parity** `V_in + V_out = V_vanilla` — the barrier-hit event `A` and its complement
+> partition every path, so the discounted expected payoffs add to the vanilla price (pure
+> linearity of expectation; no barrier density, in the register of `chooser_integral_decomp`).
+> The proof lifts the pathwise payoff split `barrier_payoff_partition`
+> (`𝟙_A·f + 𝟙_{Aᶜ}·f = f`, `Set.indicator_self_add_compl`) through `integral_indicator` +
+> `integral_add_compl`. New def `discountedValue D Q g = D·E_Q[g]` — the present-value functional
+> the pricing files had only ever written inline, now named so the three barrier values
+> (`knockInValue` / `knockOutValue` / `vanillaValue`) are thin specialisations and parity reads as
+> an identity about *values*. Axioms-clean. Provenance: the target the autoform pipeline repeatedly
+> failed to draft (depth-gate, then a hallucinated `MathFin.zcb`); authored by hand as the
+> bottleneck-locating control.
+>
+> **Prior (2026-07-18, second refined autoform PR — loaded premium principles):** corpus
 > **341**, **309 full + 18 wrappers = 327/341 delivery-ready**, 14 reduced cores, 0 placeholders.
 > `mf-insurance-premium-principles` (`Actuarial/ActuarialInsurance`, closes #85; the second
 > autoform-pipeline PR — the generalization run's output, Leanstral-drafted and -proved,

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 341 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 327 delivery-ready (full + library-wrapper).
+  scope: 342 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 328 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -106,9 +106,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 234 statements
+      lean: 235 statements
       module: benchmarks/mathematical_finance.json
-      status: full 233 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 234 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -584,6 +584,13 @@
       "input_hash": "d2ebb18fdbda3c82ac6690da30188d5a42c39f3b78a07a919186da6abd950857",
       "verified_at_commit": "ad96063"
     },
+    "mf-barrier-inout-parity": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-18",
+      "elapsed_s": 34.3,
+      "input_hash": "507107b1d94a900f4544f4e14da59d7a5c8a3583631e9121ba6628e49b70c068",
+      "verified_at_commit": "e382e1c"
+    },
     "mf-barrier-maximal-distribution": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-07-27",

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -586,10 +586,10 @@
     },
     "mf-barrier-inout-parity": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-18",
-      "elapsed_s": 34.3,
-      "input_hash": "507107b1d94a900f4544f4e14da59d7a5c8a3583631e9121ba6628e49b70c068",
-      "verified_at_commit": "e382e1c"
+      "date": "2026-07-31",
+      "elapsed_s": 137.7,
+      "input_hash": "c7e2c9191b60483a29c24285996b10efc16c511db6e151efca12234a3c040ed9",
+      "verified_at_commit": "unknown"
     },
     "mf-barrier-maximal-distribution": {
       "benchmark_file": "mathematical_finance.json",


### PR DESCRIPTION
knock-in + knock-out = vanilla. the barrier-hit event and its complement partition every path, so the discounted expected payoffs add to the vanilla price. pure linearity of expectation, no barrier density.

closes #53.

## what's here
- `MathFin/BlackScholes/BarrierParity.lean`: a named `discountedValue` present-value functional (the repo had none), the three barrier values `knockInValue` / `knockOutValue` / `vanillaValue`, the pathwise `barrier_payoff_partition` (`𝟙_A·f + 𝟙_{Aᶜ}·f = f`), and the headline `knockIn_add_knockOut_eq_vanilla`.
- benchmark `mf-barrier-inout-parity` (full), coverage live-status, AxiomAuditGen pin, formalization.yaml, ledger row.

## gates
- `lake build MathFin` green, `lake lint` passed, `pytest tests/` 28 passed, ledger 342 fresh / 0 stale / 0 missing.
- axioms-clean: `[propext, Classical.choice, Quot.sound]`.

## provenance
this is the target the autoform pipeline repeatedly failed to draft (depth-gate, then a hallucinated `MathFin.zcb`) and recorded as `needs_primitives`. it needs no primitives; proving it by hand was the phase-0 control that locates the pipeline's bottleneck at the drafter, not the prover.
