### PR TITLE
autoform: GainToPain (closes #161)

### DIFF
--- a/MathFin.lean
+++ b/MathFin.lean
@@ -438,3 +438,4 @@ import MathFin.Actuarial.SurvivalModel
 import BrownianMotion.StochasticIntegral.LocalMartingale
 import MathFin.FixedIncome.InterestRateSwap
 import MathFin.Actuarial.ActuarialInsurance
+import MathFin.Performance.GainToPain

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (281 constants). Scope: proof-position MathFin names only —
+  corpus (282 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -352,6 +352,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.ftap_discrete' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.ftap_discrete
+
+/-- info: 'MathFin.gainToPain_nonneg_of_pain_pos' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.gainToPain_nonneg_of_pain_pos
 
 /-- info: 'MathFin.garman_kohlhagen_call_formula' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.garman_kohlhagen_call_formula

--- a/MathFin/Performance/GainToPain.lean
+++ b/MathFin/Performance/GainToPain.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 Raphael Coelho. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Coelho
+-/
+module
+
+public import Mathlib
+
+-- pointers: MathFin/Performance/RatiosExtended.lean
+-- main-module: MathFin/Performance/GainToPain.lean
+-- benchmark: benchmarks/mathematical_finance.json
+-- benchmark-id: mf-performance-gain_to_pain
+-- source-issue: 161
+-- new-defs: gainToPain
+
+/-!
+Gain-to-pain ratio is nonnegative when defined.
+-/
+
+set_option autoImplicit false
+
+@[expose] public section
+
+namespace MathFin
+
+open MeasureTheory ProbabilityTheory
+open scoped NNReal ENNReal
+
+open scoped BigOperators
+
+/-- The gain-to-pain ratio is the sum of positive returns over the sum of absolute negative returns. -/
+noncomputable def gainToPain {α : Type*} (S : Finset α) (r : α → ℝ) : ℝ :=
+  (∑ s ∈ S, max (r s) 0) / (∑ s ∈ S, max (-(r s)) 0)
+
+/-- If the sum of absolute negative returns is positive, then the gain-to-pain ratio is nonnegative. -/
+theorem gainToPain_nonneg_of_pain_pos {α : Type*} (S : Finset α) (r : α → ℝ)
+    (h : 0 < ∑ s ∈ S, max (-(r s)) 0) : 0 ≤ gainToPain S r := by
+  have hnum : 0 ≤ ∑ s ∈ S, max (r s) 0 :=
+    Finset.sum_nonneg fun s _ => le_max_right _ _
+  have hden : 0 ≤ ∑ s ∈ S, max (-(r s)) 0 := h.le
+  exact div_nonneg hnum hden
+
+end MathFin

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -3778,6 +3778,32 @@
           "refined": "signature-bound def arguments + docstrings (docBlame); unused hσ_eq hypothesis and unused Insurance import removed; per-principle lemmas extracted, bundle derived from them"
         }
       }
+    },
+    {
+      "id": "mf-performance-gain_to_pain",
+      "name": "Add the gain-to-pain ratio and prove it is nonnegative",
+      "description": "Gain-to-pain ratio is nonnegative when defined.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Performance.GainToPain\n\nopen MathFin\n\n/-- Gain-to-pain ratio is nonnegative when defined. -/\ntheorem mf_performance_gain_to_pain {α : Type*} (S : Finset α) (r : α → ℝ)\n    (h : 0 < ∑ s ∈ S, max (-(r s)) 0) : 0 ≤ gainToPain S r :=\n  MathFin.gainToPain_nonneg_of_pain_pos S r h\n"
+      },
+      "metadata": {
+        "chapter": 0,
+        "reference": "Add the gain-to-pain ratio and prove it is nonnegative",
+        "difficulty": "good-first",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/Performance/GainToPain.lean (magistral-drafted statement, leanstral proof). Re-export from MathFin. Axioms-clean. Introduces definitions: gainToPain (new-defs review class).",
+        "provenance": {
+          "statement_source": "magistral-autoform",
+          "statement_model": "magistral-medium",
+          "source": "leanstral-autoform",
+          "model": "labs-leanstral-1-5",
+          "issue": 161,
+          "new_defs": [
+            "gainToPain"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -857,3 +857,55 @@ trimmed measure; when you instead extend to a `Submodule.topologicalClosure`, th
   ledger entry that transitively imports it (the whole Itô/finance chain — 36 entries, a ~50-min
   daemon `ledger verify`). Lift-to-a-shared-leaf is the right call for a genuinely generic kernel, but
   budget the re-verify; if the tree is hot and the lemma is one-off, keeping it local is cheaper.
+
+## Statement design (for the formalizer / drafter) (2026-07-18)
+
+The drafter's job is a faithful, in-depth *statement* — the hardest failures are
+not proof failures but statement failures. Design for these before writing `:= by
+sorry`.
+
+- **Shape hard side-conditions to be inherited, not asserted.** When the object is
+  a limit/closure, define it inside a class closed under the operation so the
+  condition is free: `levyClosure := (LinearMap.range emb).topologicalClosure` makes
+  `DenseRange` a soft `IsInducing.subtypeVal.dense_iff` fact — no bespoke σ-algebra.
+  Carve a `Submodule` (carrier + three closure proofs) rather than a `structure` +
+  `Module` instance. Diagonalize a matrix problem so the ODE reduces to the scalar
+  lemma. A draft that instead *asserts* the side-condition as a new hypothesis is
+  the wrong shape.
+- **Casts go outward around lattice/arith ops** to match library normal form:
+  `↑(min p t)`, not `min ↑p ↑t` — a coe-inward statement fails to unify downstream,
+  and a co-occurring "stuck metavariable" is a *symptom* of the cast mismatch, not a
+  separate problem. Fix the cast, not the instance.
+- **Name derived measures/σ-algebras** (`trimMeasure_T`, a predictable σ-algebra) as
+  defs; never inline `(P.trim …)` in a statement — the inlined form carries a
+  σ-algebra-instance mismatch the named def avoids.
+- **State Lp-class facts in `=ᵐ`/`condExp` form, not pointwise.** For a process whose
+  value is an Lp class, honest pointwise `Adapted` is awkward; the conditional-
+  expectation identity is the real content and it elaborates.
+- **State shared hypotheses in the eta-form the consumers want** (`fun ω ↦ B t ω - B s
+  ω`, not Pi-`sub`), so a defeq `exact` propagates instead of a rewrite failing.
+- **Don't quantify integrals over `↥Submodule`** — instance synthesis (`BorelSpace
+  ↥K`) fails; stay in the ambient space with subset/membership hypotheses.
+- **Natural generality** (already in the drafter contract, restated here): `s.Nonempty`
+  over a member-witness; `A ≠ 0` over provable positivity; the minimal typeclass the
+  callees need.
+
+## Repair table (compiler error → fix) (2026-07-18)
+
+The recurring error→fix mappings from the grind history. Try the mapped fix before
+a general search; most are one-line and defeq-driven.
+
+| Error signature | Fix |
+|---|---|
+| "did not find an occurrence" / "made no progress" with `(fun … ↦ …) x` or a Pi-`+`/`-`/`*` of lambdas in the goal | `show` the beta-reduced goal / `simp only []`; or type-annotate the `have` with the single-lambda form. Diagnose a stuck `convert` with `exact h`. |
+| Unknown identifier `X` | grep the **pinned** `.lake/packages/mathlib` for `X` and `Namespace.X` (loogle tracks a newer pin — upper bound only); if a sibling edited this session declares `X`, it's stale-olean: rebuild, don't respell. |
+| "typeclass instance problem is stuck `C args ?m.N`" | name the implicit at the call site (`(μ := μ)`), `@`-apply, or bind a fully-typed `have` first. |
+| "Function expected at `zero_le` … type `0 ≤ ?m`" | drop the applied argument, use the bare term; toggle the primed/unprimed variant. |
+| "unexpected token 'omit'/'set_option'; expected 'lemma'" | move the `… in` modifier **above** the docstring. |
+| mass "unknown namespace MeasureTheory" in a file importing a just-edited sibling | stale olean — rebuild the dep; do not edit the proof. |
+| Type mismatch of `Measurable`/`AEStronglyMeasurable` differing only in the `MeasurableSpace` instance | drop the explicit type annotation (let it infer the sub-σ), or `letI`-pin it. |
+| "Invalid field `f`" on an `And`/`Exists`/def-reducing-to-`And` | call `Namespace.f h …` by full name, or `obtain ⟨…⟩` first. |
+| "No goals to be solved" | delete the trailing tactic (cascade after a root error — fix only the first). |
+| "Ambiguous term X" (`intervalIntegral` vs `MeasureTheory`) | qualify by the goal's integral syntax. |
+| "failed to synthesize `LE Type`/`OfNat Type`" | `ℝ≥0` misparsed as `ℝ ≥ 0` — add `open scoped NNReal`; `𝓝` → `open Topology`. |
+| cast mismatch inside a `fun n : ℕ ↦ …` | put the ℕ-consuming atom leftmost, or ascribe the binder; write `(2:ℝ) •`, never `2 •`. |

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 341 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 327 delivery-ready (full + library-wrapper).
+  scope: 342 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 328 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -47,7 +47,7 @@ automation:
         - labs-leanstral-1-5
       framework: "mathfin-foundry: probe / vibe <-> lean-lsp-mcp"
       tool_setup: token-paced GitHub Actions pipeline; Magistral specifies the statement, Leanstral formalizes + proves it. A cheap autop tactic-probe may scout-close a goal Leanstral missed; those open as DRAFT PRs (labeled scout-proof, attributed to the tactic, refactored before merge, never silently merged). On a Leanstral pass it opens a ready-for-review PR on formal-mathfin that a human reviews (8-lens values panel) and merges
-      prompting_notes: "2 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85)"
+      prompting_notes: "3 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85, #161)"
     - method: own design, external source consulted (cited)
       models: []
       framework: Lean 4 + Mathlib, this library's conventions; an Isabelle/HOL AFP entry consulted as a source for the classical result set
@@ -106,9 +106,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 234 statements
+      lean: 235 statements
       module: benchmarks/mathematical_finance.json
-      status: full 233 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 234 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1753,6 +1753,13 @@
       "input_hash": "ebe70c2a0dce71ec428d8d3ea4cca7a525dc5dba1c2cfbaaf01ad2bbf17853c5",
       "verified_at_commit": "bfa3834"
     },
+    "mf-performance-gain_to_pain": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-20",
+      "elapsed_s": 7.8,
+      "input_hash": "be91d2a646b2ae1e65f399f376028f630437da798dd9ffc1fd2efea7db356315",
+      "verified_at_commit": "unknown"
+    },
     "mf-phi-le-one": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-07-11",


### PR DESCRIPTION
this pr was produced by the autoform pipeline (leanstral labs-leanstral-1-5), then assembled and validated green in ci. closes #161.

what it adds:
- `MathFin/Performance/GainToPain.lean` — the proof (axioms-clean; the probe's axiom guard passed).
- a re-export entry in `benchmarks/mathematical_finance.json`.
- regenerated `MathFin/AxiomAuditGen.lean` + `formalization.yaml`.


provenance: leanstral, run tag `pipeline-20260720-160954`, ~0 tokens.

review checklist (8-lens, before merge):
- [ ] the statement faithfully formalizes (its stated subset of) issue #161 — no vacuity, no weaker restatement of what it states; a declared subset is fine (see follow-ups).
- [ ] no DERIVABLE hypothesis survives (the #123 `hP` class: a positivity/side condition provable from the concrete defs — the strengthen pass only removes proof-UNUSED ones; this one needs an eye).
- [ ] the proof is idiomatic and consumes existing lemmas, not a wrapper.
- [ ] ledger row present (run `ledger verify` if ci is red on it).
- [ ] axioms clean; no slop.
- [ ] coverage.md journal block authored at merge (reviewer-written — the narrative voice stays human).

<details><summary>statement-fidelity notes</summary>

# Statement-fidelity notes — `cal-bk-161`

A reviewer's map from the informal claim to the Lean statement. The kernel checks the *proof*; it cannot check that the *statement* means the claim — that is this document's job.

**Source issue:** #161

## Lean statement (as merged)

```lean
noncomputable def gainToPain {α : Type*} (S : Finset α) (r : α → ℝ) : ℝ
```

## Existing results it builds on (pointers)

- `MathFin/Performance/RatiosExtended.lean`

## What to check

- Do the Lean hypotheses match every assumption in the informal claim (none dropped, none added)?
- Is the conclusion the same proposition, not a weaker/vacuous variant (a trivially-true `≤`, an unused binder, a hypothesis that is secretly `False`)?
- Are the domain objects the intended ones (the pointer defs above), not raw Mathlib stand-ins that only look right?

## Provenance

- statement + proof: leanstral (labs-leanstral-1-5)
- harness: vibe ⇄ lean-lsp-mcp
- scout, not author: opened by the pipeline, reviewed + merged by a human.

</details>

<details><summary>first-pass refinery punch list (mechanical lenses — soft; the human owns the rewrite)</summary>

_(first-pass refinery notes skipped: no MISTRAL_API_KEY or empty candidate)_

</details>