### PR TITLE
autoform: PerformanceRatios (closes #161)

### DIFF
--- a/MathFin.lean
+++ b/MathFin.lean
@@ -438,3 +438,4 @@ import MathFin.Actuarial.SurvivalModel
 import BrownianMotion.StochasticIntegral.LocalMartingale
 import MathFin.FixedIncome.InterestRateSwap
 import MathFin.Actuarial.ActuarialInsurance
+import MathFin.Performance.PerformanceRatios

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (281 constants). Scope: proof-position MathFin names only —
+  corpus (282 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -352,6 +352,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.ftap_discrete' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.ftap_discrete
+
+/-- info: 'MathFin.gainToPain_nonneg_of_denom_pos' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.gainToPain_nonneg_of_denom_pos
 
 /-- info: 'MathFin.garman_kohlhagen_call_formula' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.garman_kohlhagen_call_formula

--- a/MathFin/Performance/PerformanceRatios.lean
+++ b/MathFin/Performance/PerformanceRatios.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 Raphael Coelho. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Coelho
+-/
+module
+
+public import Mathlib
+
+-- pointers: MathFin/Performance/RatiosExtended.lean
+-- main-module: MathFin/Performance/PerformanceRatios.lean
+-- benchmark: benchmarks/mathematical_finance.json
+-- benchmark-id: mf-performance-gain_to_pain
+-- source-issue: 161
+-- new-defs: gainToPain
+
+/-!
+The gain-to-pain ratio is nonnegative when defined.
+-/
+
+set_option autoImplicit false
+
+@[expose] public section
+
+namespace MathFin
+
+open MeasureTheory ProbabilityTheory
+open scoped NNReal ENNReal
+
+/-- The gain-to-pain ratio for returns r over a finite set S.
+    Defined as (sum of positive returns) / (sum of absolute values of negative returns). -/
+noncomputable def gainToPain (S : Type*) (finset_S : Finset S) (r : S → ℝ) : ℝ :=
+  (∑ s ∈ finset_S, max (r s) 0) / (∑ s ∈ finset_S, max (-r s) 0)
+
+@[simp]
+example : gainToPain (Fin 1) (Finset.univ : Finset (Fin 1)) (fun _ => -1) = 0 := by
+  unfold gainToPain; norm_num
+
+@[simp]
+example : gainToPain (Fin 2) (Finset.univ : Finset (Fin 2)) (fun s => if s = 0 then 1 else -1) = 1 := by
+  unfold gainToPain; norm_num
+
+theorem gainToPain_nonneg_of_denom_pos {S : Type*} (finset_S : Finset S) (r : S → ℝ)
+    (h : 0 < ∑ s ∈ finset_S, max (-r s) 0) : 0 ≤ gainToPain S finset_S r := by
+  unfold gainToPain
+  refine div_nonneg ?_ (le_of_lt h)
+  exact Finset.sum_nonneg fun s _ => le_max_right _ _
+
+end MathFin

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -3778,6 +3778,32 @@
           "refined": "signature-bound def arguments + docstrings (docBlame); unused hσ_eq hypothesis and unused Insurance import removed; per-principle lemmas extracted, bundle derived from them"
         }
       }
+    },
+    {
+      "id": "mf-performance-gain_to_pain",
+      "name": "Add the gain-to-pain ratio and prove it is nonnegative",
+      "description": "The gain-to-pain ratio is nonnegative when defined.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Performance.PerformanceRatios\n\nopen MathFin\n\n/-- The gain-to-pain ratio is nonnegative when defined. -/\ntheorem mf_performance_gain_to_pain {S : Type*} (finset_S : Finset S) (r : S → ℝ)\n    (h : 0 < ∑ s ∈ finset_S, max (-r s) 0) : 0 ≤ gainToPain S finset_S r :=\n  MathFin.gainToPain_nonneg_of_denom_pos finset_S r h\n"
+      },
+      "metadata": {
+        "chapter": 0,
+        "reference": "Add the gain-to-pain ratio and prove it is nonnegative",
+        "difficulty": "good-first",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/Performance/PerformanceRatios.lean (magistral-drafted statement, leanstral proof). Re-export from MathFin. Axioms-clean. Introduces definitions: gainToPain (new-defs review class).",
+        "provenance": {
+          "statement_source": "magistral-autoform",
+          "statement_model": "magistral-medium",
+          "source": "leanstral-autoform",
+          "model": "labs-leanstral-1-5",
+          "issue": 161,
+          "new_defs": [
+            "gainToPain"
+          ]
+        }
+      }
     }
   ]
 }

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 341 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 327 delivery-ready (full + library-wrapper).
+  scope: 342 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 328 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -47,7 +47,7 @@ automation:
         - labs-leanstral-1-5
       framework: "mathfin-foundry: probe / vibe <-> lean-lsp-mcp"
       tool_setup: token-paced GitHub Actions pipeline; Magistral specifies the statement, Leanstral formalizes + proves it. A cheap autop tactic-probe may scout-close a goal Leanstral missed; those open as DRAFT PRs (labeled scout-proof, attributed to the tactic, refactored before merge, never silently merged). On a Leanstral pass it opens a ready-for-review PR on formal-mathfin that a human reviews (8-lens values panel) and merges
-      prompting_notes: "2 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85)"
+      prompting_notes: "3 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85, #161)"
     - method: own design, external source consulted (cited)
       models: []
       framework: Lean 4 + Mathlib, this library's conventions; an Isabelle/HOL AFP entry consulted as a source for the classical result set
@@ -106,9 +106,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 234 statements
+      lean: 235 statements
       module: benchmarks/mathematical_finance.json
-      status: full 233 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 234 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1753,6 +1753,13 @@
       "input_hash": "ebe70c2a0dce71ec428d8d3ea4cca7a525dc5dba1c2cfbaaf01ad2bbf17853c5",
       "verified_at_commit": "bfa3834"
     },
+    "mf-performance-gain_to_pain": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-25",
+      "elapsed_s": 7.8,
+      "input_hash": "0b09ad5c5c210ff6e8c62e65e3a094d1823662fa640ff7159cd71d12926a51f2",
+      "verified_at_commit": "unknown"
+    },
     "mf-phi-le-one": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-07-11",


### PR DESCRIPTION
this pr was produced by the autoform pipeline (leanstral labs-leanstral-1-5), then assembled and validated green in ci. closes #161.

what it adds:
- `MathFin/Performance/PerformanceRatios.lean` — the proof (axioms-clean; the probe's axiom guard passed).
- a re-export entry in `benchmarks/mathematical_finance.json`.
- regenerated `MathFin/AxiomAuditGen.lean` + `formalization.yaml`.


provenance: leanstral, run tag `pipeline-20260725-083629`, ~0 tokens.

review checklist (8-lens, before merge):
- [ ] the statement faithfully formalizes (its stated subset of) issue #161 — no vacuity, no weaker restatement of what it states; a declared subset is fine (see follow-ups).
- [ ] no DERIVABLE hypothesis survives (the #123 `hP` class: a positivity/side condition provable from the concrete defs — the strengthen pass only removes proof-UNUSED ones; this one needs an eye).
- [ ] the proof is idiomatic and consumes existing lemmas, not a wrapper.
- [ ] ledger row present (run `ledger verify` if ci is red on it).
- [ ] axioms clean; no slop.
- [ ] coverage.md journal block authored at merge (reviewer-written — the narrative voice stays human).

<details><summary>statement-fidelity notes</summary>

# Statement-fidelity notes — `cal-bk-161`

A reviewer's map from the informal claim to the Lean statement. The kernel checks the *proof*; it cannot check that the *statement* means the claim — that is this document's job.

**Source issue:** #161

## Lean statement (as merged)

```lean
noncomputable def gainToPain (S : Type*) (finset_S : Finset S) (r : S → ℝ) : ℝ
```

## Existing results it builds on (pointers)

- `MathFin/Performance/RatiosExtended.lean`

## What to check

- Do the Lean hypotheses match every assumption in the informal claim (none dropped, none added)?
- Is the conclusion the same proposition, not a weaker/vacuous variant (a trivially-true `≤`, an unused binder, a hypothesis that is secretly `False`)?
- Are the domain objects the intended ones (the pointer defs above), not raw Mathlib stand-ins that only look right?

## Provenance

- statement + proof: leanstral (labs-leanstral-1-5)
- harness: vibe ⇄ lean-lsp-mcp
- scout, not author: opened by the pipeline, reviewed + merged by a human.

</details>

<details><summary>first-pass refinery punch list (mechanical lenses — soft; the human owns the rewrite)</summary>

```markdown
- [ ] ZERO SLOP: unused `example` blocks with `@[simp]` (lines: "example : gainToPain (Fin 1) ..." and "example : gainToPain (Fin 2) ...")
- [ ] ZERO SLOP: gratuitous `set_option autoImplicit false`
- [ ] REGISTER: missing docstring for `gainToPain_nonneg_of_denom_pos`
- [ ] ANTI-WRAPPER: no findings (module is clean)
- [ ] OBVIOUS GOLF: no findings (module is clean)
```

</details>