### PR TITLE
autoform: PerformanceRatiosExtended (closes #162)

### DIFF
--- a/MathFin.lean
+++ b/MathFin.lean
@@ -438,3 +438,4 @@ import MathFin.Actuarial.SurvivalModel
 import BrownianMotion.StochasticIntegral.LocalMartingale
 import MathFin.FixedIncome.InterestRateSwap
 import MathFin.Actuarial.ActuarialInsurance
+import MathFin.Performance.PerformanceRatiosExtended

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (281 constants). Scope: proof-position MathFin names only —
+  corpus (282 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -823,6 +823,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.triangleNoArb_solve_third' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.triangleNoArb_solve_third
+
+/-- info: 'MathFin.upCapture_smul' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.upCapture_smul
 
 /-- info: 'MathFin.valueFunction_satisfies_approxHJ' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.valueFunction_satisfies_approxHJ

--- a/MathFin/Performance/PerformanceRatiosExtended.lean
+++ b/MathFin/Performance/PerformanceRatiosExtended.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 Raphael Coelho. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raphael Coelho
+-/
+module
+
+public import Mathlib
+
+-- pointers: MathFin/Performance/RatiosExtended.lean
+-- main-module: MathFin/Performance/PerformanceRatiosExtended.lean
+-- benchmark: benchmarks/mathematical_finance.json
+-- benchmark-id: mf-performance-upside_capture
+-- source-issue: 162
+-- new-defs: upCapture
+
+/-!
+Upside-capture ratio and its homogeneity.
+-/
+
+set_option autoImplicit false
+
+@[expose] public section
+
+namespace MathFin
+
+open MeasureTheory ProbabilityTheory
+open scoped NNReal ENNReal
+
+open scoped BigOperators
+
+/-- Upside-capture ratio: sum of portfolio returns over `up` periods divided by sum of benchmark returns over `up` periods. -/
+noncomputable def upCapture {S : Type*} (up : Finset S) (p : S → ℝ) (b : S → ℝ) : ℝ :=
+  (∑ i ∈ up, p i) / (∑ i ∈ up, b i)
+
+example : upCapture ({0,1,2} : Finset ℕ) (fun i => (i : ℝ)) (fun i => (i : ℝ) + 1) = (1/2 : ℝ) := by
+  norm_num [upCapture]
+
+theorem upCapture_smul {S : Type*} (up : Finset S) (p : S → ℝ) (b : S → ℝ) (c : ℝ)
+    (h : ∑ i ∈ up, b i ≠ 0) : upCapture up (c • p) b = c * upCapture up p b := by
+  dsimp [upCapture]
+  field_simp [h]
+  simp [Finset.mul_sum]
+
+end MathFin

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -3778,6 +3778,32 @@
           "refined": "signature-bound def arguments + docstrings (docBlame); unused hσ_eq hypothesis and unused Insurance import removed; per-principle lemmas extracted, bundle derived from them"
         }
       }
+    },
+    {
+      "id": "mf-performance-upside_capture",
+      "name": "Add the upside-capture ratio and prove positive homogeneity in the portfolio return",
+      "description": "Upside-capture ratio and its homogeneity.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Performance.PerformanceRatiosExtended\n\nopen MathFin\n\n/-- Upside-capture ratio and its homogeneity. -/\ntheorem mf_performance_upside_capture {S : Type*} (up : Finset S) (p : S → ℝ) (b : S → ℝ) (c : ℝ)\n    (h : ∑ i ∈ up, b i ≠ 0) : upCapture up (c • p) b = c * upCapture up p b :=\n  MathFin.upCapture_smul up p b c h\n"
+      },
+      "metadata": {
+        "chapter": 0,
+        "reference": "Add the upside-capture ratio and prove positive homogeneity in the portfolio return",
+        "difficulty": "small",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/Performance/PerformanceRatiosExtended.lean (magistral-drafted statement, leanstral proof). Re-export from MathFin. Axioms-clean. Introduces definitions: upCapture (new-defs review class).",
+        "provenance": {
+          "statement_source": "magistral-autoform",
+          "statement_model": "magistral-medium",
+          "source": "leanstral-autoform",
+          "model": "labs-leanstral-1-5",
+          "issue": 162,
+          "new_defs": [
+            "upCapture"
+          ]
+        }
+      }
     }
   ]
 }

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 341 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 327 delivery-ready (full + library-wrapper).
+  scope: 342 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 328 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -47,7 +47,7 @@ automation:
         - labs-leanstral-1-5
       framework: "mathfin-foundry: probe / vibe <-> lean-lsp-mcp"
       tool_setup: token-paced GitHub Actions pipeline; Magistral specifies the statement, Leanstral formalizes + proves it. A cheap autop tactic-probe may scout-close a goal Leanstral missed; those open as DRAFT PRs (labeled scout-proof, attributed to the tactic, refactored before merge, never silently merged). On a Leanstral pass it opens a ready-for-review PR on formal-mathfin that a human reviews (8-lens values panel) and merges
-      prompting_notes: "2 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85)"
+      prompting_notes: "3 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85, #162)"
     - method: own design, external source consulted (cited)
       models: []
       framework: Lean 4 + Mathlib, this library's conventions; an Isabelle/HOL AFP entry consulted as a source for the classical result set
@@ -106,9 +106,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 234 statements
+      lean: 235 statements
       module: benchmarks/mathematical_finance.json
-      status: full 233 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 234 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1753,6 +1753,13 @@
       "input_hash": "ebe70c2a0dce71ec428d8d3ea4cca7a525dc5dba1c2cfbaaf01ad2bbf17853c5",
       "verified_at_commit": "bfa3834"
     },
+    "mf-performance-upside_capture": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-26",
+      "elapsed_s": 6.8,
+      "input_hash": "c2563617bdfb14b0620abb8595b8f0782c82ce79d7a54e8bc64a75debb8489fe",
+      "verified_at_commit": "unknown"
+    },
     "mf-phi-le-one": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-07-11",


### PR DESCRIPTION
this pr was produced by the autoform pipeline (leanstral labs-leanstral-1-5), then assembled and validated green in ci. closes #162.

what it adds:
- `MathFin/Performance/PerformanceRatiosExtended.lean` — the proof (axioms-clean; the probe's axiom guard passed).
- a re-export entry in `benchmarks/mathematical_finance.json`.
- regenerated `MathFin/AxiomAuditGen.lean` + `formalization.yaml`.


provenance: leanstral, run tag `pipeline-20260726-192529`, ~0 tokens.

review checklist (8-lens, before merge):
- [ ] the statement faithfully formalizes (its stated subset of) issue #162 — no vacuity, no weaker restatement of what it states; a declared subset is fine (see follow-ups).
- [ ] no DERIVABLE hypothesis survives (the #123 `hP` class: a positivity/side condition provable from the concrete defs — the strengthen pass only removes proof-UNUSED ones; this one needs an eye).
- [ ] the proof is idiomatic and consumes existing lemmas, not a wrapper.
- [ ] ledger row present (run `ledger verify` if ci is red on it).
- [ ] axioms clean; no slop.
- [ ] coverage.md journal block authored at merge (reviewer-written — the narrative voice stays human).

<details><summary>statement-fidelity notes</summary>

# Statement-fidelity notes — `cal-bk-162`

A reviewer's map from the informal claim to the Lean statement. The kernel checks the *proof*; it cannot check that the *statement* means the claim — that is this document's job.

**Source issue:** #162

## Lean statement (as merged)

```lean
noncomputable def upCapture {S : Type*} (up : Finset S) (p : S → ℝ) (b : S → ℝ) : ℝ
```

## Existing results it builds on (pointers)

- `MathFin/Performance/RatiosExtended.lean`

## What to check

- Do the Lean hypotheses match every assumption in the informal claim (none dropped, none added)?
- Is the conclusion the same proposition, not a weaker/vacuous variant (a trivially-true `≤`, an unused binder, a hypothesis that is secretly `False`)?
- Are the domain objects the intended ones (the pointer defs above), not raw Mathlib stand-ins that only look right?

## Provenance

- statement + proof: leanstral (labs-leanstral-1-5)
- harness: vibe ⇄ lean-lsp-mcp
- scout, not author: opened by the pipeline, reviewed + merged by a human.

</details>

<details><summary>first-pass refinery punch list (mechanical lenses — soft; the human owns the rewrite)</summary>

```markdown
- [ ] ZERO SLOP: unused imports `MeasureTheory`, `ProbabilityTheory`
- [ ] ZERO SLOP: unused scoped opens `NNReal`, `ENNReal`
- [ ] ZERO SLOP: gratuitous `set_option autoImplicit false`
- [ ] REGISTER: missing docstring for `upCapture_smul`
- [ ] REGISTER: non-idiomatic `=>` in `fun i => (i : ℝ)` (should be `↦`)
- [ ] REGISTER: non-idiomatic `=>` in `fun i => (i : ℝ) + 1` (should be `↦`)
```

</details>