### PR TITLE
feat(performance): gain-to-pain + upside-capture ratios, guards dropped (closes #161, #162)

### DIFF
--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (282 constants). Scope: proof-position MathFin names only —
+  corpus (284 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -352,6 +352,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.ftap_discrete' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.ftap_discrete
+
+/-- info: 'MathFin.gainToPain_nonneg' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.gainToPain_nonneg
 
 /-- info: 'MathFin.garman_kohlhagen_call_formula' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.garman_kohlhagen_call_formula
@@ -826,6 +829,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.triangleNoArb_solve_third' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.triangleNoArb_solve_third
+
+/-- info: 'MathFin.upCapture_smul' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.upCapture_smul
 
 /-- info: 'MathFin.valueFunction_satisfies_approxHJ' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.valueFunction_satisfies_approxHJ

--- a/MathFin/Performance/RatiosExtended.lean
+++ b/MathFin/Performance/RatiosExtended.lean
@@ -9,7 +9,7 @@ public import Mathlib
 public import MathFin.Performance.Ratios
 
 /-!
-# Extended performance ratios: Sortino, Treynor, Information ratio
+# Extended performance ratios: Sortino, Treynor, Information, gain-to-pain, upside capture
 
 Standard quant performance metrics beyond the basic Sharpe ratio:
 
@@ -29,12 +29,31 @@ Sortino, Treynor, and IR are all instances of `(a − b)/d`. Their
 handles the Sharpe scale invariance — proving that the master is load-bearing
 across all four ratios in the library.)
 
+The last two are *realised* ratios: they aggregate a return path over a finite
+period set rather than combining summary moments.
+
+* **Gain-to-pain ratio** `(∑ r⁺) / (∑ r⁻)`, total gains over total losses
+  (Schwager). Written with Mathlib's positive/negative parts `r⁺ = max r 0`,
+  `r⁻ = max (-r) 0`, so `posPart_sub_negPart` supplies the decomposition
+  `∑ r⁺ − ∑ r⁻ = ∑ r` that turns "ratio ≥ 1" into "the period was profitable".
+* **Upside-capture ratio** `(∑_{up} p) / (∑_{up} b)`, portfolio gains over
+  benchmark gains on the up-market periods (Morningstar).
+
+Both are quotients, and in Lean `x / 0 = 0`; the nonnegativity and homogeneity
+statements below therefore need **no** nonvanishing side condition — the
+degenerate no-loss / flat-benchmark case is covered by the same statement. The
+one place a hypothesis is genuinely load-bearing is
+`one_le_gainToPain_iff`, where `0 < ∑ r⁻` is what makes the quotient
+comparable to `1` at all.
+
 Results:
 
 * `sortinoRatio`, `sortinoRatio_scale_invariant`, `sortinoRatio_translation`.
 * `treynorRatio`, `treynorRatio_scale_invariant`.
 * `informationRatio`, `informationRatio_scale_invariant`.
 * `trackingErrorSq`, `trackingErrorSq_self`, `trackingErrorSq_ge_diff_sq`.
+* `gainToPain`, `gainToPain_nonneg`, `one_le_gainToPain_iff`.
+* `upCapture`, `upCapture_smul`.
 -/
 
 @[expose] public section
@@ -109,5 +128,41 @@ lemma trackingErrorSq_ge_diff_sq (σ_p σ_b cov : ℝ) (h_cs : cov ≤ σ_p * σ
     (σ_p - σ_b) ^ 2 ≤ trackingErrorSq σ_p σ_b cov := by
   unfold trackingErrorSq
   nlinarith [h_cs]
+
+variable {ι : Type*}
+
+/-- **Gain-to-pain ratio** over a finite period set `s` with returns `r`: total
+gains `∑ r⁺` over total losses `∑ r⁻` (Schwager). -/
+noncomputable def gainToPain (s : Finset ι) (r : ι → ℝ) : ℝ :=
+  (∑ i ∈ s, (r i)⁺) / (∑ i ∈ s, (r i)⁻)
+
+/-- **Gain-to-pain is nonnegative**: both legs are sums of positive/negative
+parts. Unconditionally — with no losses the denominator is `0` and the ratio is
+`0`, which the statement already covers. -/
+lemma gainToPain_nonneg (s : Finset ι) (r : ι → ℝ) : 0 ≤ gainToPain s r :=
+  div_nonneg (Finset.sum_nonneg fun _ _ ↦ posPart_nonneg _)
+    (Finset.sum_nonneg fun _ _ ↦ negPart_nonneg _)
+
+/-- **Gain-to-pain exceeds one exactly on a profitable period set**: since
+`r⁺ - r⁻ = r` summand-wise, `∑ r⁺ ≥ ∑ r⁻` says precisely `∑ r ≥ 0`. Here the
+positive-pain hypothesis is load-bearing — it is what makes the quotient
+comparable to `1`. -/
+lemma one_le_gainToPain_iff (s : Finset ι) (r : ι → ℝ)
+    (h : 0 < ∑ i ∈ s, (r i)⁻) :
+    1 ≤ gainToPain s r ↔ 0 ≤ ∑ i ∈ s, r i := by
+  rw [gainToPain, one_le_div h, ← sub_nonneg, ← Finset.sum_sub_distrib]
+  simp [posPart_sub_negPart]
+
+/-- **Upside-capture ratio** over the up-market periods `up`: portfolio gains
+`∑ p` over benchmark gains `∑ b` (Morningstar). -/
+noncomputable def upCapture (up : Finset ι) (p b : ι → ℝ) : ℝ :=
+  (∑ i ∈ up, p i) / (∑ i ∈ up, b i)
+
+/-- **Upside capture is homogeneous of degree one in the portfolio leg**: the
+scalar factors out of the numerator sum, and `mul_div_assoc` carries it past the
+benchmark leg with no nonvanishing condition. -/
+lemma upCapture_smul (up : Finset ι) (p b : ι → ℝ) (c : ℝ) :
+    upCapture up (c • p) b = c * upCapture up p b := by
+  simp [upCapture, ← Finset.mul_sum, mul_div_assoc]
 
 end MathFin

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -3794,6 +3794,60 @@
           "refined": "signature-bound def arguments + docstrings (docBlame); unused hσ_eq hypothesis and unused Insurance import removed; per-principle lemmas extracted, bundle derived from them"
         }
       }
+    },
+    {
+      "id": "mf-performance-gain_to_pain",
+      "name": "Add the gain-to-pain ratio and prove it is nonnegative",
+      "description": "The gain-to-pain ratio, total gains over total losses on a finite period set, is nonnegative — unconditionally.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Performance.RatiosExtended\n\nopen MathFin\n\n/-- The gain-to-pain ratio is nonnegative: both legs are sums of positive/negative parts. -/\ntheorem mf_performance_gain_to_pain {ι : Type*} (s : Finset ι) (r : ι → ℝ) :\n    0 ≤ gainToPain s r :=\n  MathFin.gainToPain_nonneg s r\n"
+      },
+      "metadata": {
+        "chapter": 0,
+        "reference": "Add the gain-to-pain ratio and prove it is nonnegative",
+        "difficulty": "good-first",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/Performance/RatiosExtended.lean (magistral-drafted statement, leanstral proof, human-refined at review). Re-export from MathFin. Axioms-clean. Introduces definitions: gainToPain (new-defs review class).",
+        "provenance": {
+          "statement_source": "magistral-autoform",
+          "statement_model": "magistral-medium",
+          "source": "leanstral-autoform",
+          "model": "labs-leanstral-1-5",
+          "issue": 161,
+          "new_defs": [
+            "gainToPain"
+          ],
+          "refined": "spurious `0 < pain` hypothesis dropped (the drafter guarded a division Lean does not need guarding — x/0 = 0); def restated on Mathlib's posPart/negPart instead of open-coded max, which supplies posPart_sub_negPart and hence one_le_gainToPain_iff (ratio ≥ 1 ↔ the period was profitable) as the lemma that makes the definition earn its place; landed in the existing RatiosExtended module the issue named, not a new one-lemma module"
+        }
+      }
+    },
+    {
+      "id": "mf-performance-upside_capture",
+      "name": "Add the upside-capture ratio and prove homogeneity in the portfolio return",
+      "description": "The upside-capture ratio is homogeneous of degree one in the portfolio leg — unconditionally.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Performance.RatiosExtended\n\nopen MathFin\n\n/-- Upside capture is homogeneous of degree one in the portfolio return. -/\ntheorem mf_performance_upside_capture {ι : Type*} (up : Finset ι) (p b : ι → ℝ) (c : ℝ) :\n    upCapture up (c • p) b = c * upCapture up p b :=\n  MathFin.upCapture_smul up p b c\n"
+      },
+      "metadata": {
+        "chapter": 0,
+        "reference": "Add the upside-capture ratio and prove positive homogeneity in the portfolio return",
+        "difficulty": "small",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/Performance/RatiosExtended.lean (magistral-drafted statement, leanstral proof, human-refined at review). Re-export from MathFin. Axioms-clean. Introduces definitions: upCapture (new-defs review class).",
+        "provenance": {
+          "statement_source": "magistral-autoform",
+          "statement_model": "magistral-medium",
+          "source": "leanstral-autoform",
+          "model": "labs-leanstral-1-5",
+          "issue": 162,
+          "new_defs": [
+            "upCapture"
+          ],
+          "refined": "spurious `∑ b ≠ 0` hypothesis dropped (mul_div_assoc needs no nonvanishing denominator); scalar leg stated as `c • p` and the lemma named `_smul`, since the claim is degree-one homogeneity and `_scale_invariant` is already taken in this namespace by the genuinely invariant Sortino/Treynor/IR lemmas; landed in the existing RatiosExtended module the issue named, not a new one-lemma module"
+        }
+      }
     }
   ]
 }

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -26,7 +26,25 @@ Report `reduced_core` and `placeholder` separately. **Spec-with-axiomatized-conc
 
 ## Current Audit
 
-> **Live status (2026-07-18, in-out barrier parity — closes #53):** corpus
+> **Live status (2026-07-31, gain-to-pain + upside capture — closes #161, #162):** corpus
+> **344**, **312 full + 18 wrappers = 330/344 delivery-ready**, 14 reduced cores, 0 placeholders.
+> `mf-performance-gain_to_pain` and `mf-performance-upside_capture`
+> (`Performance/RatiosExtended`): the two realised-path ratios join the four moment ratios
+> already in that module. `gainToPain` is written on Mathlib's positive/negative parts
+> (`r⁺`, `r⁻`) rather than open-coded `max _ 0`, which buys `posPart_sub_negPart` and hence
+> `one_le_gainToPain_iff` — the ratio clears 1 exactly when the period was profitable, the
+> statement that makes the definition worth having. `upCapture_smul` is degree-one
+> homogeneity in the portfolio leg.
+>
+> Both landed as **one** refined change consolidating four duplicate autoform PRs
+> (#163/#165 for #161, #164/#167 for #162 — the pipeline drafted each target twice). Each
+> draft carried a **spurious division guard** (`0 < ∑ r⁻`, `∑ b ≠ 0`) that neither issue
+> asked for and neither proof needs: in Lean `x / 0 = 0`, so nonnegativity and homogeneity
+> both hold unconditionally. The guards are dropped, so the merged statements are strictly
+> *stronger* than the drafted ones. Each draft also created a new one-lemma module instead of
+> the `RatiosExtended` module both issues named; consolidated. Axioms-clean.
+>
+> **Prior (2026-07-18, in-out barrier parity — closes #53):** corpus
 > **342**, **310 full + 18 wrappers = 328/342 delivery-ready**, 14 reduced cores, 0 placeholders.
 > `mf-barrier-inout-parity` (`BlackScholes/BarrierParity`, closes #53): knock-in / knock-out
 > **in-out parity** `V_in + V_out = V_vanilla` — the barrier-hit event `A` and its complement

--- a/docs/values-review.md
+++ b/docs/values-review.md
@@ -74,6 +74,68 @@ Entries from 2026-06-29 (corpus 302, the whole-repo review below) onward use the
 PASS / PASS-WITH-NOTES verdicts, kept as-is — the transition itself was an upgrade to lens 4 (the review
 should *generate work*, not certify "OK").
 
+## 2026-07-31 — corpus 344 — open-PR review round: the spurious-guard class
+
+Scope: the eight open PRs, not a new proof program. Deviation from protocol worth naming — this
+round was adjudicated by a single reviewer rather than a three-agent panel, so treat the per-lens
+gradients below as one reading, and re-run the panel at the next proof session.
+
+**Upgrades executed.**
+
+1. **Lens 3 (zero slop) + lens 5 (first principles) — the headline.** All four autoform PRs for
+   #161/#162 shipped a **division guard the theorem does not need**: `0 < ∑ r⁻` on gain-to-pain
+   nonnegativity, `∑ b ≠ 0` on upside-capture homogeneity. In Lean `x / 0 = 0`, so `div_nonneg`
+   over two nonneg sums and `mul_div_assoc` both discharge unconditionally. Neither issue asked
+   for the guard — the drafter added it. Both dropped; the merged statements are strictly
+   stronger than what was drafted. This is the *dead-hypothesis* failure mode, and it is the one
+   the kernel cannot see: a weaker theorem type-checks exactly as happily as a strong one.
+2. **Lens 2 (coherence).** `gainToPain` restated on Mathlib's `posPart`/`negPart` (`r⁺`, `r⁻`)
+   instead of open-coded `max _ 0`. That is not cosmetic: it is what makes
+   `posPart_sub_negPart` available, and hence `one_le_gainToPain_iff`.
+3. **Lens 1 (inspired math).** `0 ≤ gainToPain` is bookkeeping — it says a quotient of
+   nonnegatives is nonnegative and nothing about finance. `one_le_gainToPain_iff` (the ratio
+   clears 1 exactly when `0 ≤ ∑ r`) is the statement that makes the definition worth having, and
+   it is where a positivity hypothesis is genuinely load-bearing. Added alongside.
+4. **Lens 4 (architecture).** Four PRs created four new one-lemma modules
+   (`GainToPain`, `PerformanceRatios`, `UpCapture`, `PerformanceRatiosExtended`) when both issues
+   named `Performance/RatiosExtended.lean`, beside the four ratios they belong with. Consolidated
+   into one change in that module; four duplicate PRs closed.
+5. **Lens 6 (idiomatic register).** `upCapture_scale_invariant` renamed `upCapture_smul`: the
+   claim is degree-one homogeneity, and `_scale_invariant` is already taken in this namespace by
+   Sortino/Treynor/IR, which genuinely *are* invariant (`f (c • x) = f x`). Scalar leg stated as
+   `c • p`. Also removed: unused `open MeasureTheory ProbabilityTheory` / `open scoped NNReal
+   ENNReal BigOperators` in every draft, and an `@[simp]` attached to an `example` (a no-op).
+
+**Ranked backlog.**
+
+1. **A redundant-hypothesis prober, in the foundry gate chain.** The spurious guard slipped
+   through four independent drafts and a kernel check. It is mechanically detectable: after a
+   proof lands, re-elaborate it with each hypothesis deleted in turn; anything that still
+   compiles was decorative. Seconds per target on the daemon, no model in the loop. This is the
+   single highest-value gate the pipeline is missing — owner: foundry.
+2. **`AxiomAuditGen` misses bundle-shaped proof terms.** The generator only picks up qualified
+   `:= MathFin.X`, so a benchmark closed by `⟨MathFin.a …, MathFin.b …⟩` (PR #166's FRA entry)
+   escapes the exhaustive audit entirely. #166's author noticed and hand-added to the *curated*
+   `AxiomAudit.lean` — the right instinct, but it silently promotes an ordinary entry into the
+   headliner file. Extend the extractor to walk anonymous constructors and `And.intro` spines.
+3. **`formalization.yaml`'s automation disclosure is pinned to a retired pipeline.**
+   `tools/formalization_yaml.py:164,238,240` hardcode "statement specified by Magistral" +
+   `magistral-medium`, and `tests/test_formalization_yaml.py:113-115` *asserts* it. Magistral left
+   the foundry on 2026-07-29 (`docs/upgrade-backlog.md`). Today's file is still accurate for
+   today's corpus — every autoform entry in it was drafted before the cutover — but the next one
+   will make the disclosure false. Needs a decision, not a patch: the drafter is now Claude, and
+   standing policy is that Claude is never attributed. Owner: R.
+4. **`docs/patterns.md`: fold in the guard rule.** The file already carries "check the sign on a
+   scale-invariance / homogeneity claim" (2026-07-19) and "`A ≠ 0` over provable positivity".
+   The neighbouring rule this round earned — *no guard on a division unless the conclusion
+   actually breaks at zero* — belongs beside them, aimed at the drafter.
+
+**Evidence / context.** Mechanical floor green on the integrated tree: full `lake build` 8981
+jobs, `ledger status` 344/344 fresh (all four new entries re-verified through the daemon at the
+v4.32.0 pin), 30/30 python gates, `AxiomAuditGen` byte-fresh at 284 guards. Note the pin
+interaction that would otherwise have pushed main red: every one of these PRs was built against
+the pre-#168 toolchain, so all of them carried stale entry hashes.
+
 ## 2026-07-16 — corpus 335 — multi-asset matrix Riccati (BEGV Prop 2) via spectral reduction
 
 `Foundations/MatrixMarketMakingRiccati` (M1 abstract matrix Riccati `a' = a·a − Â·Â` solved in closed

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 342 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 328 delivery-ready (full + library-wrapper).
+  scope: 344 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 330 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -47,7 +47,7 @@ automation:
         - labs-leanstral-1-5
       framework: "mathfin-foundry: probe / vibe <-> lean-lsp-mcp"
       tool_setup: token-paced GitHub Actions pipeline; Magistral specifies the statement, Leanstral formalizes + proves it. A cheap autop tactic-probe may scout-close a goal Leanstral missed; those open as DRAFT PRs (labeled scout-proof, attributed to the tactic, refactored before merge, never silently merged). On a Leanstral pass it opens a ready-for-review PR on formal-mathfin that a human reviews (8-lens values panel) and merges
-      prompting_notes: "2 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85)"
+      prompting_notes: "4 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85, #161, #162)"
     - method: own design, external source consulted (cited)
       models: []
       framework: Lean 4 + Mathlib, this library's conventions; an Isabelle/HOL AFP entry consulted as a source for the classical result set
@@ -106,9 +106,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 235 statements
+      lean: 237 statements
       module: benchmarks/mathematical_finance.json
-      status: full 234 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 236 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1475,10 +1475,10 @@
     },
     "mf-information-ratio-scale-invariant": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.0,
-      "input_hash": "d5f3d04500c224845ddc8c92f401efe75f76253170256e72a2155c7abb1f7627",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 163.2,
+      "input_hash": "a4b4116808e704d51046a2f23133d3da2bc428d2a8e8fc1cc70b20d2b20c481e",
+      "verified_at_commit": "unknown"
     },
     "mf-insurance-premium-principles": {
       "benchmark_file": "mathematical_finance.json",
@@ -1760,6 +1760,20 @@
       "input_hash": "31398f085cd2c681ab17f50a814d77b876fe3e6a86463d40dfad1e40fa9cb2c1",
       "verified_at_commit": "ad96063"
     },
+    "mf-performance-gain_to_pain": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-31",
+      "elapsed_s": 95.9,
+      "input_hash": "239b66cd7cd1b38f2c09a009b4a213d62ef6de22e5ebe667471733f371739592",
+      "verified_at_commit": "unknown"
+    },
+    "mf-performance-upside_capture": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-31",
+      "elapsed_s": 59.8,
+      "input_hash": "df31e60ecee0679150ca40e97c7f532b4dc886184c2f5d3a03d857584ee645ca",
+      "verified_at_commit": "unknown"
+    },
     "mf-phi-le-one": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-07-27",
@@ -1853,17 +1867,17 @@
     },
     "mf-sortino-scale-invariant": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.0,
-      "input_hash": "d34c04261c5a0b8f2e4559d5ec8af7ac89b31115a88c2d4859b3df6730244221",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 105.3,
+      "input_hash": "f4292a118b3a471eed759adcd3485b5e8131a71e5947fecac9b636eb9cd83c44",
+      "verified_at_commit": "unknown"
     },
     "mf-sortino-translation": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 3.5,
-      "input_hash": "94eac74e45829289368e1ce050bf74cb7bbcf448592a9bab42b970bac77fd0d0",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 128.2,
+      "input_hash": "a177d1f24b8fc737cae060f2b94ebec503dadd1299f3b51174417cf65a239d4a",
+      "verified_at_commit": "unknown"
     },
     "mf-spectral-risk-translation": {
       "benchmark_file": "mathematical_finance.json",
@@ -1951,24 +1965,24 @@
     },
     "mf-tracking-error-cauchy-bound": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.5,
-      "input_hash": "0ba6ee73a24cdb0385c109fa05651700aadad66cf6f7a60bcee06eb50f395d25",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 108.3,
+      "input_hash": "351298bf3864d3390a363f464108e5e4b95f0c6d8dbced3f281accf0ba57750c",
+      "verified_at_commit": "unknown"
     },
     "mf-tracking-error-self": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.4,
-      "input_hash": "97480a6c2e9d307e5adbd7ec5aa7fafa39398a30dee8bc1ff03649b5092b2b7d",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 137.7,
+      "input_hash": "faefcabb0f19177076fdec164ab3004c88e8b1a7eb0b70a8684513a2214d07ae",
+      "verified_at_commit": "unknown"
     },
     "mf-treynor-scale-invariant": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.2,
-      "input_hash": "b122ae218f0adecd231eebd4e66054e828711d746618cc123728536ff0efa6ed",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 104.4,
+      "input_hash": "3a6928e1604657ad7a93a0b71b9849a448e53d70150f47cab2b78dbf6be4b06b",
+      "verified_at_commit": "unknown"
     },
     "mf-triangle-arbitrage-unique": {
       "benchmark_file": "mathematical_finance.json",


### PR DESCRIPTION
consolidates the four duplicate autoform PRs for #161/#162 into one refined change, and drops a spurious hypothesis both of them carried.

supersedes #163, #164, #165, #167.

## what changed vs the drafts

**the division guards are gone.** every draft asserted a side condition neither issue asked for:

- `gainToPain_nonneg_of_pain_pos (h : 0 < ∑ max (-r s) 0)`
- `upCapture_scale_invariant (h : ∑ b s ≠ 0)`

neither proof uses them. in Lean `x / 0 = 0`, so `div_nonneg` over two nonneg sums and `mul_div_assoc` both discharge unconditionally. the merged statements are strictly stronger than what was drafted. this is the dead-hypothesis failure mode and the kernel cannot see it — a weaker theorem type-checks exactly as happily.

**placement.** both issues say `location: MathFin/Performance/RatiosExtended.lean`. the four drafts created four new one-lemma modules instead (`GainToPain`, `PerformanceRatios`, `UpCapture`, `PerformanceRatiosExtended`), each with its own umbrella import. they now sit in `RatiosExtended` beside the four moment ratios, and the umbrella needs no edit.

**`gainToPain` on `posPart`/`negPart`.** `r⁺`/`r⁻` instead of open-coded `max _ 0`. not cosmetic — it makes `posPart_sub_negPart` available, which gives `one_le_gainToPain_iff`: the ratio clears 1 exactly when `0 ≤ ∑ r`. that is the statement that makes the definition worth having; `0 ≤ gainToPain` on its own says a quotient of nonnegatives is nonnegative and nothing about finance. it is also where a positivity hypothesis is genuinely load-bearing, which is the contrast worth keeping in the file.

**naming.** `upCapture_smul`, not `_scale_invariant`. the claim is degree-one homogeneity, and `_scale_invariant` is already taken in this namespace by the Sortino/Treynor/IR lemmas, which genuinely are invariant (`f (c • x) = f x`).

**dropped from the drafts:** unused `open MeasureTheory ProbabilityTheory` / `open scoped NNReal ENNReal BigOperators`, and an `@[simp]` attached to an `example` (a no-op).

## verification

- full `lake build` green on the integrated tree (8981 jobs)
- `ledger status` 344/344 fresh — both new entries verified through the lean-repl daemon at the v4.32.0 pin, plus the six sibling `RatiosExtended` importers the edit restaled
- 30/30 python gates, `AxiomAuditGen` byte-fresh
- values-review entry recorded (`docs/values-review.md`)

## note on provenance

the entries record `statement_source: magistral-autoform`. that is accurate for these artifacts — both were drafted 2026-07-25/26, before magistral left the foundry on 2026-07-29. it is not a claim about the current pipeline.