### PR TITLE
feat(greeks): BS speed + Black-76 speed and caplet/floorlet parity (closes #8, #27)

### DIFF
--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (284 constants). Scope: proof-position MathFin names only —
+  corpus (287 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -233,6 +233,9 @@ namespace MathFin.AxiomAuditGen
 /-- info: 'MathFin.butterfly_payoff_nonneg' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.butterfly_payoff_nonneg
 
+/-- info: 'MathFin.caplet_floorlet_parity' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.caplet_floorlet_parity
+
 /-- info: 'MathFin.cappedCall_eq_bull_spread' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.cappedCall_eq_bull_spread
 
@@ -446,6 +449,9 @@ namespace MathFin.AxiomAuditGen
 /-- info: 'MathFin.hasDerivAt_blackV_FF' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_blackV_FF
 
+/-- info: 'MathFin.hasDerivAt_blackV_FFF' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_blackV_FFF
+
 /-- info: 'MathFin.hasDerivAt_blackV_T' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_blackV_T
 
@@ -535,6 +541,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.hasDerivAt_bsV_KK' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_KK
+
+/-- info: 'MathFin.hasDerivAt_bsV_SSS' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_SSS
 
 /-- info: 'MathFin.hasDerivAt_bsV_charm' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_charm

--- a/MathFin/BlackScholes/HigherGreeks.lean
+++ b/MathFin/BlackScholes/HigherGreeks.lean
@@ -103,4 +103,38 @@ lemma hasDerivAt_bsV_charm {K r σ : ℝ} (hσ : 0 < σ)
   have h_Phi_d1 := (hasDerivAt_Phi (bsd1 S K r σ τ)).comp τ h_d1_τ
   convert h_Phi_d1 using 1 <;> rfl
 
+/-- **Speed**: `∂³V/∂S³ = ∂Γ/∂S = -ϕ(d₁) (d₁ + σ√τ) / (S² σ² τ)`.
+
+Gamma is the quotient `ϕ(d₁(S)) / (S σ √τ)` (`hasDerivAt_bsV_SS`), so speed is
+one quotient rule away. Numerator derivative is `ϕ'(d₁) ∂_S d₁ = -d₁ ϕ(d₁)/(S σ √τ)`;
+denominator derivative is the constant `σ √τ`. The two contributions carry `d₁`
+and `σ√τ` respectively, which is where the `d₁ + σ√τ` numerator comes from —
+and note the denominator is `S² σ² τ`, not `S² σ √τ`. -/
+lemma hasDerivAt_bsV_SSS {K r σ : ℝ} (hK : 0 < K) (hσ : 0 < σ)
+    {S τ : ℝ} (hS : 0 < S) (hτ : 0 < τ) :
+    HasDerivAt (fun s ↦ gaussianPDFReal 0 1 (bsd1 s K r σ τ) / (s * σ * Real.sqrt τ))
+      (-(gaussianPDFReal 0 1 (bsd1 S K r σ τ) * (bsd1 S K r σ τ + σ * Real.sqrt τ)
+        / (S ^ 2 * σ ^ 2 * τ))) S := by
+  have h_sqrt_pos : 0 < Real.sqrt τ := Real.sqrt_pos.mpr hτ
+  have h_sqrt_ne : Real.sqrt τ ≠ 0 := h_sqrt_pos.ne'
+  have hσ_ne : σ ≠ 0 := hσ.ne'
+  have hS_ne : S ≠ 0 := hS.ne'
+  have h_num := (hasDerivAt_gaussianPDFReal_zero_one (bsd1 S K r σ τ)).comp S
+    (hasDerivAt_bsd1_S (r := r) hK hσ hτ hS)
+  have h_den : HasDerivAt (fun s : ℝ ↦ s * σ * Real.sqrt τ) (σ * Real.sqrt τ) S := by
+    simpa using ((hasDerivAt_id S).mul_const σ).mul_const (Real.sqrt τ)
+  -- Pin the quotient's expected type so `.div` elaborates against the goal's
+  -- instances rather than handing back a Pi-`/` of functions.
+  have h : HasDerivAt (fun s ↦ gaussianPDFReal 0 1 (bsd1 s K r σ τ) / (s * σ * Real.sqrt τ))
+      ((-(bsd1 S K r σ τ * gaussianPDFReal 0 1 (bsd1 S K r σ τ)) * (1 / (S * σ * Real.sqrt τ))
+            * (S * σ * Real.sqrt τ)
+          - gaussianPDFReal 0 1 (bsd1 S K r σ τ) * (σ * Real.sqrt τ))
+        / (S * σ * Real.sqrt τ) ^ 2) S :=
+    h_num.div h_den (by positivity)
+  convert h using 1
+  rw [show S ^ 2 * σ ^ 2 * τ = (S * σ * Real.sqrt τ) ^ 2 from by
+    rw [mul_pow, mul_pow, Real.sq_sqrt hτ.le]]
+  field_simp
+  ring
+
 end MathFin

--- a/MathFin/Futures/Black76.lean
+++ b/MathFin/Futures/Black76.lean
@@ -122,4 +122,45 @@ theorem blackPayerSwaption_eq_bsVGarman (A F K σ T : ℝ) (hA : 0 < A) :
   unfold blackPayerSwaption bsVGarman
   rw [hd1, hd2]; ring
 
+/-! ## Black-76 caplet and floorlet
+
+A **caplet** is a European call on a forward rate, scaled by the accrual factor
+`α` over the accrual period; a **floorlet** is its put counterpart. Both follow
+the same no-separate-discount convention as the swaption above — the forward
+numéraire absorbs the drift, so the discount does not appear in the formula.
+
+Written out, the caplet is `α · [F Φ(d₁) − K Φ(d₂)]`, which is the payer
+swaption's formula with the accrual factor sitting in the annuity slot. That is
+not a coincidence worth hiding: `blackCaplet_eq_blackPayerSwaption` records it,
+and caplet-floorlet parity is then the payer-receiver parity already proved
+above, applied. -/
+
+/-- **Black-76 caplet price**: `α · [F Φ(d₁) − K Φ(d₂)]`, the accrual-scaled
+Black-76 call on the forward rate `F`, with `d_i = bsd_i F K 0 σ T`. -/
+noncomputable def blackCaplet (F K σ T α : ℝ) : ℝ :=
+  α * (F * Phi (bsd1 F K 0 σ T) - K * Phi (bsd2 F K 0 σ T))
+
+/-- **Black-76 floorlet price**: `α · [K Φ(−d₂) − F Φ(−d₁)]`, the put counterpart
+of `blackCaplet`. -/
+noncomputable def blackFloorlet (F K σ T α : ℝ) : ℝ :=
+  α * (K * Phi (-(bsd2 F K 0 σ T)) - F * Phi (-(bsd1 F K 0 σ T)))
+
+/-- **The caplet is a payer swaption in disguise**: same Black-76 shape, with the
+accrual factor `α` where the swaption carries its annuity `A`. The two
+instruments differ in their numéraire story, not in their formula. -/
+theorem blackCaplet_eq_blackPayerSwaption (F K σ T α : ℝ) :
+    blackCaplet F K σ T α = blackPayerSwaption α F K σ T := rfl
+
+/-- **The floorlet is a receiver swaption in disguise**, by the same reading. -/
+theorem blackFloorlet_eq_blackReceiverSwaption (F K σ T α : ℝ) :
+    blackFloorlet F K σ T α = blackReceiverSwaption α F K σ T := rfl
+
+/-- **Caplet-floorlet parity**: `V^caplet − V^floorlet = α · (F − K)`, the
+forward-rate analogue of put-call parity. Given the structural identity above it
+*is* payer-receiver parity, so it is that theorem applied rather than the same
+`Phi`-symmetry argument run a second time. -/
+theorem caplet_floorlet_parity (F K σ T α : ℝ) :
+    blackCaplet F K σ T α - blackFloorlet F K σ T α = α * (F - K) :=
+  swaption_payer_receiver_parity α F K σ T
+
 end MathFin

--- a/MathFin/Futures/Black76Greeks.lean
+++ b/MathFin/Futures/Black76Greeks.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib
 public import MathFin.Futures.Black76
 public import MathFin.BlackScholes.PDE
+public import MathFin.BlackScholes.HigherGreeks
 
 /-!
 # Black-76 Greeks
@@ -49,6 +50,19 @@ lemma hasDerivAt_blackV_FF {K σ : ℝ} (hK : 0 < K) (hσ : 0 < σ) (r : ℝ)
   have h := h_bs.const_mul (Real.exp (-(r * T)))
   convert h using 1 <;> try rfl
   ring
+
+/-- **Black-76 speed**: `∂³_F V_B = e^{-rT} · (-ϕ(d₁) (d₁ + σ√T) / (F² σ² T))`.
+
+Same shape as the other Black-76 Greeks: the discount factor does not depend on
+`F`, so it rides through the differentiation as a constant multiplier on the
+zero-drift BS speed. -/
+lemma hasDerivAt_blackV_FFF {K σ : ℝ} (hK : 0 < K) (hσ : 0 < σ) (r : ℝ)
+    {F T : ℝ} (hF : 0 < F) (hT : 0 < T) :
+    HasDerivAt (fun f ↦ Real.exp (-(r * T)) *
+        (gaussianPDFReal 0 1 (bsd1 f K 0 σ T) / (f * σ * Real.sqrt T)))
+      (Real.exp (-(r * T)) * -(gaussianPDFReal 0 1 (bsd1 F K 0 σ T) *
+        (bsd1 F K 0 σ T + σ * Real.sqrt T) / (F ^ 2 * σ ^ 2 * T))) F :=
+  (hasDerivAt_bsV_SSS (r := 0) hK hσ hF hT).const_mul (Real.exp (-(r * T)))
 
 /-- **Black-76 vega**: `∂_σ V_B = e^{-rT} · F · ϕ(d₁) · √T`. -/
 lemma hasDerivAt_blackV_sigma {K : ℝ} (hK : 0 < K) (r : ℝ)

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -3872,6 +3872,54 @@
           "refined": "spurious `∑ b ≠ 0` hypothesis dropped (mul_div_assoc needs no nonvanishing denominator); scalar leg stated as `c • p` and the lemma named `_smul`, since the claim is degree-one homogeneity and `_scale_invariant` is already taken in this namespace by the genuinely invariant Sortino/Treynor/IR lemmas; landed in the existing RatiosExtended module the issue named, not a new one-lemma module"
         }
       }
+    },
+    {
+      "id": "mf-bs-speed",
+      "name": "BS Speed (∂³V/∂S³)",
+      "description": "BS speed ∂³V/∂S³ = ∂Γ/∂S = -ϕ(d₁)(d₁ + σ√τ)/(S² σ² τ), one quotient rule on the gamma expression ϕ(d₁)/(S σ √τ).",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.BlackScholes.HigherGreeks\n\nopen MathFin ProbabilityTheory\n\n/-- BS speed: the third spot derivative of the call, i.e. the spot derivative of gamma. -/\ntheorem mf_bs_speed {K r σ : ℝ} (hK : 0 < K) (hσ : 0 < σ)\n    {S τ : ℝ} (hS : 0 < S) (hτ : 0 < τ) :\n    HasDerivAt (fun s => gaussianPDFReal 0 1 (bsd1 s K r σ τ) / (s * σ * Real.sqrt τ))\n      (-(gaussianPDFReal 0 1 (bsd1 S K r σ τ) * (bsd1 S K r σ τ + σ * Real.sqrt τ)\n        / (S ^ 2 * σ ^ 2 * τ))) S :=\n  MathFin.hasDerivAt_bsV_SSS hK hσ hS hτ\n"
+      },
+      "metadata": {
+        "chapter": 9,
+        "reference": "BS speed (Wystup 2002; Hull 19.4)",
+        "difficulty": "advanced",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/BlackScholes/HigherGreeks.lean, beside vanna/volga/charm. Quotient rule on the gamma expression, with the chain rule ϕ'(d₁) = -d₁·ϕ(d₁) supplying the numerator derivative; the σ²τ denominator (not σ√τ) is where the two contributions combine. Re-export from MathFin. Axioms-clean."
+      }
+    },
+    {
+      "id": "mf-black76-speed",
+      "name": "Black-76 Speed",
+      "description": "Black-76 speed ∂³_F V_B = e^{-rT}·(-ϕ(d₁)(d₁ + σ√T)/(F² σ² T)): the discount factor is F-independent, so it rides through as a constant multiplier on the zero-drift BS speed.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Futures.Black76Greeks\n\nopen MathFin ProbabilityTheory\n\n/-- Black-76 speed: the zero-drift BS speed carried through the discount factor. -/\ntheorem mf_black76_speed {K σ : ℝ} (hK : 0 < K) (hσ : 0 < σ) (r : ℝ)\n    {F T : ℝ} (hF : 0 < F) (hT : 0 < T) :\n    HasDerivAt (fun f => Real.exp (-(r * T)) *\n        (gaussianPDFReal 0 1 (bsd1 f K 0 σ T) / (f * σ * Real.sqrt T)))\n      (Real.exp (-(r * T)) * -(gaussianPDFReal 0 1 (bsd1 F K 0 σ T) *\n        (bsd1 F K 0 σ T + σ * Real.sqrt T) / (F ^ 2 * σ ^ 2 * T))) F :=\n  MathFin.hasDerivAt_blackV_FFF hK hσ r hF hT\n"
+      },
+      "metadata": {
+        "chapter": 9,
+        "reference": "Black-76 speed (Hull 17.6)",
+        "difficulty": "advanced",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/Futures/Black76Greeks.lean. Bare-term const_mul of the r = 0 BS speed, matching the shape of the sibling Black-76 greeks: e^{-rT} stays live in both the function and the value, so r is load-bearing. Re-export from MathFin. Axioms-clean."
+      }
+    },
+    {
+      "id": "mf-caplet-floorlet-parity",
+      "name": "Black-76 Caplet-Floorlet Parity",
+      "description": "V^caplet - V^floorlet = α·(F - K), the forward-rate analogue of put-call parity. The caplet/floorlet pair is the payer/receiver swaption pair with the accrual factor in the annuity slot, so parity is that theorem applied.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Futures.Black76\n\nopen MathFin\n\n/-- Caplet-floorlet parity, the forward-rate analogue of put-call parity. -/\ntheorem mf_caplet_floorlet_parity (F K σ T α : ℝ) :\n    blackCaplet F K σ T α - blackFloorlet F K σ T α = α * (F - K) :=\n  MathFin.caplet_floorlet_parity F K σ T α\n"
+      },
+      "metadata": {
+        "chapter": 9,
+        "reference": "Black-76 caplet/floorlet parity (Hull 29.2)",
+        "difficulty": "advanced",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof in MathFin/Futures/Black76.lean. Derived by application of swaption_payer_receiver_parity rather than re-running the Phi-symmetry argument: blackCaplet_eq_blackPayerSwaption records that the caplet is the payer swaption's formula with the accrual factor where the annuity sits. The caplet and floorlet price definitions are exercised through this identity and the ledger; they carry no separate benchmark entry, since price-equals-definition closes by rfl. Re-export from MathFin. Axioms-clean."
+      }
     }
   ]
 }

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -26,7 +26,27 @@ Report `reduced_core` and `placeholder` separately. **Spec-with-axiomatized-conc
 
 ## Current Audit
 
-> **Live status (2026-07-31, forward-rate agreement — closes #67):** corpus **345**,
+> **Live status (2026-07-31, speed greeks + caplet/floorlet parity — closes #8, #27):** corpus
+> **348**, **316 full + 18 wrappers = 334/348 delivery-ready**, 14 reduced cores, 0 placeholders.
+> Three entries finishing two contributions that had been open since June (#36, #38, mertunsall)
+> and had gone stale against the pin bump.
+> `mf-bs-speed` (`BlackScholes/HigherGreeks`): **speed** `∂³V/∂S³ = ∂Γ/∂S =
+> -ϕ(d₁)(d₁ + σ√τ)/(S²σ²τ)`. Placed beside vanna/volga/charm rather than in the PDE file —
+> gamma *is* the quotient `ϕ(d₁)/(S σ √τ)` (`hasDerivAt_bsV_SS`), so speed is one quotient rule
+> away, with `ϕ'(d₁) = -d₁ϕ(d₁)` supplying the numerator derivative. The contribution also
+> corrected the formula in issue #8, which was algebraically wrong.
+> `mf-black76-speed` (`Futures/Black76Greeks`): the discount factor is `F`-independent, so the
+> Black-76 speed is a bare-term `const_mul` of the `r = 0` BS speed, with `e^{-rT}` live in both
+> the function and the value — matching the sibling greeks, so the `r` binder is load-bearing.
+> `mf-caplet-floorlet-parity` (`Futures/Black76`): `V^caplet - V^floorlet = α·(F - K)`, derived by
+> *applying* `swaption_payer_receiver_parity` rather than re-running the same `Phi`-symmetry
+> argument — `blackCaplet_eq_blackPayerSwaption` records that a caplet is the payer swaption's
+> formula with the accrual factor where the annuity sits. The caplet and floorlet price
+> definitions carry no benchmark entry of their own: price-equals-definition closes by `rfl`, so
+> they are exercised through the parity identity and the ledger instead, and the
+> definitional-`rfl` allowlist stays empty. Axioms-clean.
+>
+> **Prior (2026-07-31, forward-rate agreement — closes #67):** corpus **345**,
 > **313 full + 18 wrappers = 331/345 delivery-ready**, 14 reduced cores, 0 placeholders.
 > `mf-fixedincome-fra` (`FixedIncome/FRA`, closes #67; the first outside contribution to the
 > corpus): the simple forward rate `F = (P(0,T₁)/P(0,T₂) - 1)/δ`, FRA value

--- a/docs/values-review.md
+++ b/docs/values-review.md
@@ -74,7 +74,7 @@ Entries from 2026-06-29 (corpus 302, the whole-repo review below) onward use the
 PASS / PASS-WITH-NOTES verdicts, kept as-is — the transition itself was an upgrade to lens 4 (the review
 should *generate work*, not certify "OK").
 
-## 2026-07-31 — corpus 344 — open-PR review round: the spurious-guard class
+## 2026-07-31 — corpus 348 — open-PR review round: the spurious-guard class
 
 Scope: the eight open PRs, not a new proof program. Deviation from protocol worth naming — this
 round was adjudicated by a single reviewer rather than a three-agent panel, so treat the per-lens
@@ -100,7 +100,19 @@ gradients below as one reading, and re-run the panel at the next proof session.
    (`GainToPain`, `PerformanceRatios`, `UpCapture`, `PerformanceRatiosExtended`) when both issues
    named `Performance/RatiosExtended.lean`, beside the four ratios they belong with. Consolidated
    into one change in that module; four duplicate PRs closed.
-5. **Lens 6 (idiomatic register).** `upCapture_scale_invariant` renamed `upCapture_smul`: the
+5. **Lens 4 again, on the two stale outside PRs (#36, #38).** Both had sat six weeks with
+   review feedback unaddressed and had gone stale against the pin bump; finished in-session
+   rather than closed. Two placement/derivation calls beyond the original submissions: *speed*
+   moved out of `BlackScholes/PDE.lean` into `HigherGreeks.lean` beside vanna/volga/charm, since
+   gamma is literally the quotient `ϕ(d₁)/(S σ √τ)` and speed is one quotient rule off it; and
+   *caplet-floorlet parity* is now `swaption_payer_receiver_parity` **applied**, not the same
+   `Phi`-symmetry argument run twice — `blackCaplet_eq_blackPayerSwaption` says why (the caplet
+   is the payer swaption with the accrual factor in the annuity slot). The submitted `rfl`-backed
+   price entries were dropped rather than allowlisted, keeping `DEFINITIONAL_RFL_ALLOWLIST`
+   empty. Note the pin interaction: the original proof used `HasDerivAt.mul`, which no longer
+   elaborates against the goal's instances on Mathlib 81a5d257 — `HasDerivAt.div` with a pinned
+   expected type does, and is the conceptually right rule anyway.
+6. **Lens 6 (idiomatic register).** `upCapture_scale_invariant` renamed `upCapture_smul`: the
    claim is degree-one homogeneity, and `_scale_invariant` is already taken in this namespace by
    Sortino/Treynor/IR, which genuinely *are* invariant (`f (c • x) = f x`). Scalar leg stated as
    `c • p`. Also removed: unused `open MeasureTheory ProbabilityTheory` / `open scoped NNReal

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -25,7 +25,7 @@ sources:
     author_contacted: n/a
     prior_work: ""
 status:
-  scope: 345 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 331 delivery-ready (full + library-wrapper).
+  scope: 348 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 334 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -106,9 +106,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 238 statements
+      lean: 241 statements
       module: benchmarks/mathematical_finance.json
-      status: full 237 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 240 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -635,10 +635,10 @@
     },
     "mf-black-futures": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 4.9,
-      "input_hash": "b49ee332c3847c9bd1b2009b7f66422946345a2a9a8e41911173042f6b3508b6",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 105.7,
+      "input_hash": "c8ee8a81a99352ba8dd0f7937a9c6771efe3a830c5fb2ee1ab76fea0d71ab833",
+      "verified_at_commit": "8f313aa"
     },
     "mf-black-litterman-1d-mean": {
       "benchmark_file": "mathematical_finance.json",
@@ -656,38 +656,45 @@
     },
     "mf-black76-delta": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.5,
-      "input_hash": "95efcfbeecaa7894c724ca2680666506346d3d51b5486ec22a7e32c4f7803354",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 111.3,
+      "input_hash": "4e28cd2ac7192098151a96407b210d8e8ee595cdee2c48d8f7c1cf4c8f56228a",
+      "verified_at_commit": "8f313aa"
     },
     "mf-black76-gamma": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.6,
-      "input_hash": "ebb6e12f3007646a5f2008bd0f9c84b94e20640edebd9f031d1aae6e0263ba24",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 74.0,
+      "input_hash": "73a5cc433d6cf88b873f6f46631769f4e7d9b232c372252fc1567c938a76366d",
+      "verified_at_commit": "8f313aa"
     },
     "mf-black76-rho": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.3,
-      "input_hash": "6be3b6ea5f16df093c4d04b21dd949114cc606e7b67f22e3b3801ce4f2fc18c2",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 123.7,
+      "input_hash": "784728d702ae1052bfeaaf950ec27a2f028ad8dea8aa1dd98efaf8108bee9fab",
+      "verified_at_commit": "8f313aa"
+    },
+    "mf-black76-speed": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-31",
+      "elapsed_s": 74.0,
+      "input_hash": "61390bfc941dd1a28c138426fc2e1e3b5620bdd141d22e54c26b03166d40975d",
+      "verified_at_commit": "8f313aa"
     },
     "mf-black76-theta": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.0,
-      "input_hash": "b52d0400b5f7a311b250f4ca0baf406f50dd0b425c90285afc9dca3747fb41c9",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 126.5,
+      "input_hash": "fef3ee7de5f3f93e8d6efddd847c4d3267b796ade901703317a18653cf464cf4",
+      "verified_at_commit": "8f313aa"
     },
     "mf-black76-vega": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.1,
-      "input_hash": "9bdb3dad90eca41faa882431cec1ef0cd72b909685d2651e58d5ec42a760422f",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 72.4,
+      "input_hash": "6279dd53390e53697246f211d5646ddb5776d79258ef81b5e9cda0dac1b6fdf3",
+      "verified_at_commit": "8f313aa"
     },
     "mf-bond-2nd-deriv": {
       "benchmark_file": "mathematical_finance.json",
@@ -789,10 +796,10 @@
     },
     "mf-bs-charm": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.2,
-      "input_hash": "ea3e198b3e1d37e367f130b61b716b99ff89c5112cc92b5d686fa44fe31d95db",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 103.9,
+      "input_hash": "e2c2f40945dada8a76cf45450eb77cb5adf81b4f48012c236d0aab23f6dd9c04",
+      "verified_at_commit": "8f313aa"
     },
     "mf-bs-dividends-call": {
       "benchmark_file": "mathematical_finance.json",
@@ -885,19 +892,26 @@
       "input_hash": "6a2ff19699c1b084cd5f562a50fda45e7c8bdf099af9a57b58e7ad1ed3bb5cf9",
       "verified_at_commit": "ad96063"
     },
+    "mf-bs-speed": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-31",
+      "elapsed_s": 66.8,
+      "input_hash": "7aace75ab4f4c7c58e7b8b9657968a345382f6b00720f2a34cc82f9bdf241fad",
+      "verified_at_commit": "8f313aa"
+    },
     "mf-bs-vanna": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 3.5,
-      "input_hash": "ad46b6db6a39e5044deadcb8d263ac91192fde24e9b1fb3ab6f9bd822f265d0b",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 83.2,
+      "input_hash": "7de21791895a20bbc6e1b32c7c3a8a6e5b4df927fe6f1edebf2e6bdf8f089b65",
+      "verified_at_commit": "8f313aa"
     },
     "mf-bs-volga": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 5.8,
-      "input_hash": "fd06d727e306f340cfca892354a492ab6a38d0e44fa10ba0e7b151cf1129a7c6",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 63.3,
+      "input_hash": "252e1ee6f5812740ae847d659efc60fc64f3124c70d99e925d1e2fee0c561d7e",
+      "verified_at_commit": "8f313aa"
     },
     "mf-bsP-K-deriv": {
       "benchmark_file": "mathematical_finance.json",
@@ -975,6 +989,13 @@
       "elapsed_s": 5.6,
       "input_hash": "c7fa634710c601315dca07bf77e07f1109bdbb17be00f020f8bd992ef7335169",
       "verified_at_commit": "ad96063"
+    },
+    "mf-caplet-floorlet-parity": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-07-31",
+      "elapsed_s": 65.2,
+      "input_hash": "fbf83dcb73312bb2f139b57ee3ab185a1c9fc5f3f52de213761970d6718d2ffd",
+      "verified_at_commit": "8f313aa"
     },
     "mf-capm-beta-linearity-finset": {
       "benchmark_file": "mathematical_finance.json",
@@ -1951,10 +1972,10 @@
     },
     "mf-swaption-parity": {
       "benchmark_file": "mathematical_finance.json",
-      "date": "2026-07-27",
-      "elapsed_s": 3.5,
-      "input_hash": "b7f3cebd081bdf2511c16c0f66cb7e48b02b423597f60908f2fc0f2b9d74fe7d",
-      "verified_at_commit": "ad96063"
+      "date": "2026-07-31",
+      "elapsed_s": 65.4,
+      "input_hash": "37de93fec09b2800e753a0afdb4f3424be594faa1a9928da93136cb173cc94a8",
+      "verified_at_commit": "8f313aa"
     },
     "mf-tangent-portfolio-N-sufficient": {
       "benchmark_file": "mathematical_finance.json",


### PR DESCRIPTION
finishes two contributions from @mertunsall that had been open since june with review feedback pending, and had gone stale against the #168 pin bump. supersedes #36 and #38; the derivations are theirs, commits credit them.

## what carried over unchanged

the BS speed derivation is mert's and it is correct. issue #8's target formula `ϕ(d₁)(2d₁d₂−1)/(S²σ√τ)` really was wrong; the product rule gives `-ϕ(d₁)(d₁ + σ√τ)/(S²σ²τ)`, which is what landed.

## what changed, and why

**speed moved to `HigherGreeks.lean`.** it is a third-order greek and belongs beside vanna/volga/charm, not in the PDE forward-direction file. this is not just filing: gamma *is* the quotient `ϕ(d₁)/(S σ √τ)` (`hasDerivAt_bsV_SS`), so speed is one quotient rule off it, and `HasDerivAt.div` says that directly.

**the proof needed rebuilding for the new pin.** the original used `HasDerivAt.mul`, which on Mathlib 81a5d257 hands back a Pi-`*` of lambdas and then fails to unify — `instAddCommGroup` vs `normedCommRing.toAddCommGroup`. `.div` with a pinned expected type elaborates against the goal's instances, and is the conceptually right rule regardless.

**`hasDerivAt_blackV_FFF` rewritten as reviewed on #36.** as submitted the statement dropped `e^{-rT}`, so it reduced to `hasDerivAt_bsV_SSS` at `r = 0` rather than being a speed of `blackV` — and the `r` binder, the `const_mul` step and the `unfold blackV` were all dead, since the proof finished on `simpa using h_bs`. it now keeps `e^{-rT}` in both the function and the value, matching `hasDerivAt_blackV_FF` above it, and is a bare term:

```lean
(hasDerivAt_bsV_SSS (r := 0) hK hσ hF hT).const_mul (Real.exp (-(r * T)))
```

**caplet/floorlet parity is derived, not re-proved.** `blackCaplet` is `blackPayerSwaption` with the accrual factor where the annuity sits, and `blackFloorlet` likewise. rather than run the same `Phi_add_Phi_neg` argument a second time through a calc block, `blackCaplet_eq_blackPayerSwaption` records the structural identity and parity is the swaption parity applied:

```lean
theorem caplet_floorlet_parity (F K σ T α : ℝ) :
    blackCaplet F K σ T α - blackFloorlet F K σ T α = α * (F - K) :=
  swaption_payer_receiver_parity α F K σ T
```

**the two `rfl` price entries are dropped, not allowlisted.** as reviewed on #38: `mf-caplet-price` / `mf-floorlet-price` were price-equals-the-definition and closed by `rfl`. the defs are exercised through the parity identity and the ledger, so `DEFINITIONAL_RFL_ALLOWLIST` stays empty and `tests/test_values.py` is untouched.

## verification

- full `lake build` green; `ledger status` 348/348 fresh (13 entries re-verified through the daemon at the v4.32.0 pin — the three new ones plus the ten greeks the edited modules restaled)
- 30/30 python gates, `AxiomAuditGen` regenerated
- coverage + values-review updated