### PR TITLE
fix(audit,disclosure): pin bundle-shaped proofs; derive the automation disclosure

### DIFF
--- a/MathFin/AxiomAudit.lean
+++ b/MathFin/AxiomAudit.lean
@@ -93,12 +93,6 @@ namespace MathFin.AxiomAudit
 /-- info: 'MathFin.forwardRate_eq_neg_log_discount' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms MathFin.forwardRate_eq_neg_log_discount
 
-/-- info: 'MathFin.fraValue_zcb_eq_discount_difference' depends on axioms: [propext, Classical.choice, Quot.sound] -/
-#guard_msgs in #print axioms MathFin.fraValue_zcb_eq_discount_difference
-
-/-- info: 'MathFin.fraValue_zcb_eq_zero_iff' depends on axioms: [propext, Classical.choice, Quot.sound] -/
-#guard_msgs in #print axioms MathFin.fraValue_zcb_eq_zero_iff
-
 /-- info: 'MathFin.force_eq_neg_log_deriv_survival' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms MathFin.force_eq_neg_log_deriv_survival
 

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (287 constants). Scope: proof-position MathFin names only —
+  corpus (304 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -64,6 +64,12 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.Phi_le_one' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.Phi_le_one
+
+/-- info: 'MathFin.PoissonCounting.map_count_eq_poissonMeasure' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.PoissonCounting.map_count_eq_poissonMeasure
+
+/-- info: 'MathFin.PoissonInterarrival.map_firstArrival_eq_expMeasure' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.PoissonInterarrival.map_firstArrival_eq_expMeasure
 
 /-- info: 'MathFin.PoissonInterarrival.survival_factorizes' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.PoissonInterarrival.survival_factorizes
@@ -221,6 +227,9 @@ namespace MathFin.AxiomAuditGen
 /-- info: 'MathFin.bs_dividends_call_formula' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.bs_dividends_call_formula
 
+/-- info: 'MathFin.bs_pde_holds' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.bs_pde_holds
+
 /-- info: 'MathFin.bs_put_call_parity' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.bs_put_call_parity
 
@@ -265,6 +274,12 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.cml_sharpeRatio_invariant' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.cml_sharpeRatio_invariant
+
+/-- info: 'MathFin.cml_weight_recovers_stdev' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.cml_weight_recovers_stdev
+
+/-- info: 'MathFin.cml_weight_unique' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.cml_weight_unique
 
 /-- info: 'MathFin.coherentRisk_isLUB' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.coherentRisk_isLUB
@@ -352,6 +367,12 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.forward_price_eq_spot_div_discount' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.forward_price_eq_spot_div_discount
+
+/-- info: 'MathFin.fraValue_zcb_eq_discount_difference' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.fraValue_zcb_eq_discount_difference
+
+/-- info: 'MathFin.fraValue_zcb_eq_zero_iff' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.fraValue_zcb_eq_zero_iff
 
 /-- info: 'MathFin.ftap_discrete' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.ftap_discrete
@@ -542,6 +563,12 @@ namespace MathFin.AxiomAuditGen
 /-- info: 'MathFin.hasDerivAt_bsV_KK' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_KK
 
+/-- info: 'MathFin.hasDerivAt_bsV_S' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_S
+
+/-- info: 'MathFin.hasDerivAt_bsV_SS' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_SS
+
 /-- info: 'MathFin.hasDerivAt_bsV_SSS' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_SSS
 
@@ -553,6 +580,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.hasDerivAt_bsV_sigma' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_sigma
+
+/-- info: 'MathFin.hasDerivAt_bsV_t' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_t
 
 /-- info: 'MathFin.hasDerivAt_bsV_vanna' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.hasDerivAt_bsV_vanna
@@ -704,8 +734,20 @@ namespace MathFin.AxiomAuditGen
 /-- info: 'MathFin.minimum_survival' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.minimum_survival
 
+/-- info: 'MathFin.mmHalfSpread_const' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.mmHalfSpread_const
+
+/-- info: 'MathFin.mmSkew_linear' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.mmSkew_linear
+
 /-- info: 'MathFin.modifiedNumerator_eq_macaulayNumerator_div' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.modifiedNumerator_eq_macaulayNumerator_div
+
+/-- info: 'MathFin.newtonSeq_tendsto_root' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.newtonSeq_tendsto_root
+
+/-- info: 'MathFin.newtonStep_quadratic_error' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.newtonStep_quadratic_error
 
 /-- info: 'MathFin.noArbitrage_of_emm_multi' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.noArbitrage_of_emm_multi
@@ -754,6 +796,15 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.quanto_correction_factor' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.quanto_correction_factor
+
+/-- info: 'MathFin.quoteConstA' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.quoteConstA
+
+/-- info: 'MathFin.quoteConstB' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.quoteConstB
+
+/-- info: 'MathFin.reflectionPrincipleEquiv_below' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.reflectionPrincipleEquiv_below
 
 /-- info: 'MathFin.reflection_principle_card' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.reflection_principle_card

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -43,8 +43,8 @@ automation:
       prompting_notes: author edits MathFin/<Section>/*.lean directly
     - method: machine autoformalization (two-stage; scout, not author)
       models:
-        - magistral-medium
         - labs-leanstral-1-5
+        - magistral-medium
       framework: "mathfin-foundry: probe / vibe <-> lean-lsp-mcp"
       tool_setup: token-paced GitHub Actions pipeline; Magistral specifies the statement, Leanstral formalizes + proves it. A cheap autop tactic-probe may scout-close a goal Leanstral missed; those open as DRAFT PRs (labeled scout-proof, attributed to the tactic, refactored before merge, never silently merged). On a Leanstral pass it opens a ready-for-review PR on formal-mathfin that a human reviews (8-lens values panel) and merges
       prompting_notes: "4 autoformalized proof(s) merged (two-stage: statement specified by Magistral, formalization + proof by Leanstral) (closing #66, #85, #161, #162)"

--- a/tests/test_formalization_yaml.py
+++ b/tests/test_formalization_yaml.py
@@ -11,6 +11,7 @@
    axioms, sorry=0) track the live corpus.
 """
 
+import json
 import os
 
 from tools import formalization_yaml as F
@@ -104,16 +105,51 @@ def test_autoform_provenance_count_is_mechanical(tmp_path):
 
 
 def test_autoform_disclosure_is_two_stage():
-    # the automation disclosure names BOTH pipeline stages honestly: Magistral
-    # specifies the statement (statement_source), Leanstral formalizes + proves —
-    # not only the leanstral prover — and discloses the autop scout mechanism.
+    # the automation disclosure names BOTH pipeline stages honestly: whoever
+    # specified the statement (statement_source), and Leanstral formalizing +
+    # proving — not only the prover — plus the autop scout mechanism.
     doc = F.build_doc(ROOT)
     method = next(m for m in doc["automation"]["methods"]
                   if "labs-leanstral-1-5" in m.get("models", []))
-    assert "magistral-medium" in method["models"]
     note = method["prompting_notes"]
-    assert "Magistral" in note and "Leanstral" in note
+    assert "Leanstral" in note
+    assert "specified by" in note and "formalization + proof by" in note
     assert "autop" in method["tool_setup"]
+
+
+def test_autoform_disclosure_is_derived_not_pinned_to_a_pipeline(tmp_path):
+    # the drafter named in the disclosure comes from the CORPUS, so it cannot
+    # outlive the pipeline it describes. Magistral drafted every autoform entry
+    # merged before it left on 2026-07-29; an entry drafted after must not inherit
+    # that claim just because the generator hardcoded it.
+    (tmp_path / "benchmarks").mkdir()
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "formalization_meta.toml").write_text("", encoding="utf-8")
+
+    def write(prov):
+        (tmp_path / "benchmarks" / "b.json").write_text(json.dumps({"theorems": [
+            {"id": "x", "name": "x", "domain": "mathematical_finance",
+             "code": {"lean": "x"},
+             "metadata": {"formalization_status": "full", "provenance": prov}}]}),
+            encoding="utf-8")
+
+    write({"source": "leanstral-autoform", "issue": 1,
+           "statement_source": "magistral-autoform", "statement_model": "magistral-medium"})
+    doc = F.build_doc(str(tmp_path))
+    note = _machine_note(doc)
+    method = next(m for m in doc["automation"]["methods"]
+                  if "labs-leanstral-1-5" in m.get("models", []))
+    assert "Magistral" in note and "magistral-medium" in method["models"]
+
+    # same corpus shape, drafter unattributed (the post-cutover convention)
+    write({"source": "leanstral-autoform", "issue": 1,
+           "statement_source": "autoform", "statement_model": "autoform"})
+    doc2 = F.build_doc(str(tmp_path))
+    method2 = next(m for m in doc2["automation"]["methods"]
+                   if "labs-leanstral-1-5" in m.get("models", []))
+    assert "Magistral" not in _machine_note(doc2)
+    assert "magistral-medium" not in method2["models"]
+    assert "Magistral" not in method2["tool_setup"]
 
 
 def test_autoform_count_matches_corpus_provenance():

--- a/tools/formalization_yaml.py
+++ b/tools/formalization_yaml.py
@@ -139,6 +139,8 @@ def build_doc(root: str) -> dict:
     # disclosure MECHANICAL — it cannot drift from a hand-set number.
     afp_count = 0
     afp_issues: list = []
+    autoform_models: set = set()
+    autoform_drafters: set = set()
     for base, t in _theorems(root):
         n += 1
         md = t.get("metadata") or {}
@@ -149,6 +151,22 @@ def build_doc(root: str) -> dict:
             autoform_count += 1
             if prov.get("issue") is not None:
                 autoform_issues.append(prov["issue"])
+            # The disclosure names the models the CORPUS actually records, rather
+            # than a pipeline hardcoded here. The pipeline changes (magistral was the
+            # statement drafter until 2026-07-29, then left entirely); a hardcoded
+            # sentence stays accurate only until the next entry lands, and this file
+            # is the public AI-disclosure artifact — the one place a stale claim is
+            # least acceptable. Entries keep their own historical attribution.
+            # the prover is fixed by `source == leanstral-autoform`; the drafter
+            # model is whatever the entry recorded, and is simply absent once the
+            # convention went drafter-agnostic
+            autoform_models.add(str(prov.get("model") or "labs-leanstral-1-5"))
+            sm = prov.get("statement_model")
+            if sm and sm != "autoform":
+                autoform_models.add(str(sm))
+            src = prov.get("statement_source")
+            if src and src != "autoform":
+                autoform_drafters.add(str(src).replace("-autoform", ""))
         elif prov.get("source") == "afp-actuarial-mathematics":
             afp_count += 1
             if prov.get("issue") is not None:
@@ -160,8 +178,13 @@ def build_doc(root: str) -> dict:
         d[status] = d.get(status, 0) + 1
 
     ready = totals["full"] + totals["library_wrapper"]
+    # Two-stage is the shape; WHO fills each stage is read off the corpus, so this
+    # sentence cannot outlive the pipeline it describes. Entries drafted before a model
+    # left keep naming it — that is their honest history — and a drafter the entries do
+    # not name is not invented here (the current drafter is deliberately unattributed).
+    drafter = ", ".join(sorted(autoform_drafters)).title() or "an unnamed drafter"
     autoform_note = (f"{autoform_count} autoformalized proof(s) merged "
-                     "(two-stage: statement specified by Magistral, formalization + proof by "
+                     f"(two-stage: statement specified by {drafter}, formalization + proof by "
                      "Leanstral)")
     if autoform_issues:
         issues = ", ".join("#" + str(i) for i in sorted(set(autoform_issues)))
@@ -235,9 +258,9 @@ def build_doc(root: str) -> dict:
                 },
                 {
                     "method": "machine autoformalization (two-stage; scout, not author)",
-                    "models": ["magistral-medium", "labs-leanstral-1-5"],
+                    "models": sorted(autoform_models) or ["labs-leanstral-1-5"],
                     "framework": "mathfin-foundry: probe / vibe <-> lean-lsp-mcp",
-                    "tool_setup": ("token-paced GitHub Actions pipeline; Magistral specifies the "
+                    "tool_setup": (f"token-paced GitHub Actions pipeline; {drafter} specifies the "
                                    "statement, Leanstral formalizes + proves it. A cheap autop "
                                    "tactic-probe may scout-close a goal Leanstral missed; those "
                                    "open as DRAFT PRs (labeled scout-proof, attributed to the "

--- a/tools/verify/axiom_audit_gen.py
+++ b/tools/verify/axiom_audit_gen.py
@@ -45,6 +45,46 @@ GEN_PATH = Path("MathFin/AxiomAuditGen.lean")
 # position, so capturing them is correct.
 PROOF_HEAD_RE = re.compile(r":=\s*\(*\s*(MathFin\.[A-Za-z_][A-Za-z0-9_.']*)")
 
+# Any MathFin constant anywhere in a proof BODY. The head match above sees only
+# the first name, so a benchmark closed by a bundle — `⟨MathFin.a …, MathFin.b …⟩`,
+# or an `And.intro` spine — put every constant but the first outside the audit.
+# `mf-fixedincome-fra` (PR #166) hit exactly this: both its theorems escaped the
+# generated audit entirely, and the contributor hand-added them to the CURATED
+# AxiomAudit.lean, which is meant for headliners rather than routine entries.
+MATHFIN_NAME_RE = re.compile(r"(MathFin\.[A-Za-z_][A-Za-z0-9_.']*)")
+
+# Start of a declaration, to bound a proof body: everything from a decl's `:=`
+# up to the next decl is proof position; past that is the next statement.
+DECL_START_RE = re.compile(
+    r"(?m)^\s*(?:@\[[^\]]*\]\s*)?(?:private\s+|protected\s+|noncomputable\s+)*"
+    r"(?:theorem|lemma|def|abbrev|instance|example)\b")
+
+_OPEN, _CLOSE = "([{", ")]}"
+
+
+def proof_bodies(code: str) -> list[str]:
+    """The proof-position spans of a benchmark snippet: for each declaration, the
+    text from its top-level `:=` to the start of the next declaration.
+
+    Bounding by the next declaration is what keeps this proof-position only — the
+    scope the generated audit claims. A `:=` nested inside brackets (a named
+    argument, a structure instance) is not the proof separator, so the scan tracks
+    depth the same way `ledger`/`af_parse` do."""
+    starts = [m.start() for m in DECL_START_RE.finditer(code)] + [len(code)]
+    out: list[str] = []
+    for i in range(len(starts) - 1):
+        seg = code[starts[i]:starts[i + 1]]
+        depth = 0
+        for j, c in enumerate(seg):
+            if c in _OPEN:
+                depth += 1
+            elif c in _CLOSE:
+                depth -= 1
+            elif c == ":" and depth == 0 and j + 1 < len(seg) and seg[j + 1] == "=":
+                out.append(seg[j + 2:])
+                break
+    return out
+
 STANDARD_AXIOMS = "[propext, Classical.choice, Quot.sound]"
 
 # name -> full #guard_msgs doc-comment body, for results whose axiom set is a
@@ -58,6 +98,8 @@ def collect_proof_position_names() -> list[str]:
     for _path, theorem in iter_entries():
         code = theorem.get("code", {}).get("lean", "")
         names.update(PROOF_HEAD_RE.findall(code))
+        for body in proof_bodies(code):
+            names.update(MATHFIN_NAME_RE.findall(body))
     return sorted(names)
 
 


### PR DESCRIPTION
two honesty gaps from the open-PR review round. both are cases where the mechanism looked fine and the claim it produced was wrong.

## `AxiomAuditGen` missed bundle-shaped proofs

`PROOF_HEAD_RE` matched a qualified `MathFin.X` **at the head** of a proof term. a benchmark closed by a bundle put every constant but the first outside the exhaustive audit:

```lean
theorem mf_fixedincome_fra … :=
  ⟨MathFin.fraValue_zcb_eq_discount_difference r δ K T1 T2 hδ,
   MathFin.fraValue_zcb_eq_zero_iff r δ K T1 T2 hδ⟩
```

neither name was pinned. #166's author noticed the gap and hand-added both to the **curated** `AxiomAudit.lean` — the right instinct, wrong file: that one is the storied headliner audit, not the place for a routine fixed-income entry.

the extractor now walks each declaration's proof body, bounded by the start of the next declaration so the "proof-position only" scope still holds (a `:=` nested inside brackets is not the proof separator, so the scan tracks depth). **284 → 304 guards**; the two FRA names move to the generated file and come out of the curated one.

the other 18 are constants that were already load-bearing in proof position and simply never got pinned — `bs_pde_holds`, `hasDerivAt_bsV_SS`, `newtonSeq_tendsto_root` among them.

## the automation disclosure was pinned to a retired pipeline

`tools/formalization_yaml.py` hardcoded `"statement specified by Magistral"` and `magistral-medium` (:164, :238, :240), and `tests/test_formalization_yaml.py` **asserted** those strings. magistral left the foundry on 2026-07-29. so the sentence was accurate for today's corpus and would have been false for the next entry — in `formalization.yaml`, which is the public AI-disclosure artifact.

the fix is not a rename. the drafter name and the model list are now read off the corpus's own per-entry `provenance`, so the disclosure cannot outlive the pipeline it describes:

- **output today is unchanged** — all four autoform entries really were magistral-drafted, and they keep that attribution, which is their honest history
- an entry recorded drafter-agnostically (`statement_source: autoform`, the post-cutover convention) no longer inherits the claim
- the prover is always named, since `source == leanstral-autoform` fixes it

the test now checks the *derivation* both ways rather than pinning a model name.

deliberately **not** decided here: what the disclosure should say once a Claude-drafted entry lands. standing policy is that Claude is never attributed, so that is a wording call, not a patch — the generator just stops asserting anything the corpus does not record.

## verification

- 31/31 python gates; `formalization.yaml` fresh; ledger 348/348 fresh
- the 20 new `#print axioms` guards are checked by `lake build` here — that is what this PR needs CI for