### PR TITLE
test(disclosure): a generated artifact must not name a component the corpus lacks

### DIFF
--- a/tests/test_generated_claims.py
+++ b/tests/test_generated_claims.py
@@ -1,0 +1,98 @@
+"""A generated artifact must not assert a component the data does not record.
+
+`formalization.yaml` is the public AI-disclosure file, and it used to hardcode
+"statement specified by Magistral" + `magistral-medium` in the generator source
+(`tools/formalization_yaml.py`), with a test asserting those strings. Magistral left
+the pipeline on 2026-07-29; the sentence stayed true only because no entry had merged
+since. The class of bug is general — a generated file naming a live component it did
+not read from the corpus — so this checks the property rather than the one instance.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+
+from tools import formalization_yaml as F
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Vendor / model vocabulary. The generated DISCLOSURE may name one of these only if the
+# corpus's own provenance records it. Extend when a new engine enters the pipeline.
+COMPONENT_WORDS = (
+    "magistral", "leanstral", "mistral", "claude", "gpt", "gemini", "llama",
+    "deepseek", "qwen", "kimi", "grok",
+)
+
+# The narrower set the GENERATOR SOURCE may not hardcode: engines that can occupy the
+# DRAFTER slot, which is the part that changes. Leanstral (and Mistral, its vendor) are
+# excluded because the prover is fixed by `provenance.source == leanstral-autoform` —
+# naming it is a consequence of the data, not an assumption about the pipeline. Claude
+# is excluded here only because it appears in an unrelated method (the interactive
+# human-authoring disclosure); if it ever leaks into the MACHINE method,
+# `test_the_disclosure_names_only_components_the_corpus_records` catches it.
+DRAFTER_WORDS = tuple(w for w in COMPONENT_WORDS
+                      if w not in ("leanstral", "mistral", "claude"))
+
+
+def _corpus_provenance_blob() -> str:
+    """Everything the corpus records about how its entries were produced."""
+    out = []
+    for path in glob.glob(os.path.join(ROOT, "benchmarks", "*.json")):
+        data = json.load(open(path, encoding="utf-8"))
+        for t in (data.get("theorems", data) if isinstance(data, dict) else data):
+            md = t.get("metadata") or {}
+            out.append(json.dumps(md.get("provenance") or {}))
+            out.append(str(md.get("formalization_scope") or ""))
+    return " ".join(out).lower()
+
+
+def _machine_method(doc: dict) -> dict:
+    for m in doc["automation"]["methods"]:
+        if any("leanstral" in str(x).lower() for x in m.get("models", [])):
+            return m
+    raise AssertionError("machine autoformalization method not found")
+
+
+def test_the_disclosure_names_only_components_the_corpus_records():
+    # the machine-autoformalization disclosure tracks the pipeline, so every engine it
+    # names must be one the corpus actually attributes an entry to
+    method = _machine_method(F.build_doc(ROOT))
+    text = " ".join([json.dumps(method.get("models", [])),
+                     str(method.get("prompting_notes", "")),
+                     str(method.get("tool_setup", ""))]).lower()
+    corpus = _corpus_provenance_blob()
+    unbacked = [w for w in COMPONENT_WORDS if w in text and w not in corpus]
+    assert not unbacked, (
+        "formalization.yaml's automation disclosure names "
+        f"{unbacked} but no benchmark entry's provenance records it — the generator is "
+        "asserting a pipeline the corpus does not attest. Regenerate from provenance "
+        "rather than hardcoding (tools/formalization_yaml.py).")
+
+
+def test_the_generator_does_not_hardcode_a_drafter_into_the_prose():
+    # the failure mode was a DRAFTER name baked into an f-string, invisible until the
+    # corpus moved on: "statement specified by Magistral" survived the model leaving the
+    # pipeline. See DRAFTER_WORDS for why the prover is exempt.
+    src = open(os.path.join(ROOT, "tools", "formalization_yaml.py"), encoding="utf-8").read()
+    code = "\n".join(l for l in src.splitlines() if not l.strip().startswith("#"))
+    hits = set()
+    for w in DRAFTER_WORDS:
+        for m in re.finditer(rf'["\'][^"\']*{w}[^"\']*["\']', code, re.I):
+            hits.add(m.group(0))
+    assert not hits, (
+        "these string literals name a pipeline component inside the generator, so the "
+        f"disclosure cannot follow the corpus when the pipeline changes: {sorted(hits)}")
+
+
+def test_the_corpus_still_backs_what_the_disclosure_says_today():
+    # a live sanity check on the derivation: the entries ARE magistral-drafted today,
+    # so the disclosure naming Magistral is correct — and this test is what will fail
+    # (pointing at the generator) once that stops being true
+    method = _machine_method(F.build_doc(ROOT))
+    corpus = _corpus_provenance_blob()
+    for model in method.get("models", []):
+        base = str(model).lower()
+        assert any(w in corpus for w in COMPONENT_WORDS if w in base) or "leanstral" in base, (
+            f"disclosure lists model {model!r} with no corpus provenance behind it")


### PR DESCRIPTION
follow-up to #171. that PR fixed the instance; this pins the property.

## what it checks

**the disclosure may only name engines the corpus attests.** the machine-autoformalization method's models + prose are scanned for a vendor/model vocabulary, and each hit must appear in some benchmark entry's `provenance`. a name that survives only in generator source now fails.

**the generator source may not hardcode a drafter.** that is where the bug actually lived — `"statement specified by Magistral"` inside an f-string, invisible until the corpus moved on. the prover is exempt, and the exemption is principled rather than a carve-out: `provenance.source == leanstral-autoform` *fixes* the prover, so naming it is a consequence of the data. `claude` is exempt from the source check only because it appears in the unrelated interactive-human-authoring method; if it ever leaks into the machine method, the first check catches it.

## verification

reintroduced the bug (`drafter = "Magistral"` hardcoded) and confirmed the source check fails; reverted and 34/34 gates are green. today's output is unchanged — all four autoform entries really are magistral-drafted, so the disclosure naming Magistral is correct, and this is what will fail, pointing at the generator, once that stops being true.

## why this class

three of the four findings from the open-PR review round were a record asserting something the available evidence contradicted, with nothing checking. this is the cheapest of those to make mechanical.