### PR TITLE
merge verification_ledger.json semantically, and gate the push

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# `verification_ledger.json` is a flat {id: row} map of DERIVED state. Git's
+# default text merge combines two branches silently whenever they touch
+# different regions of it — which on 2026-08-07 dropped a row during the #173
+# merge and put main red. Route it through the semantic driver instead, which
+# unions disjoint verifications and DROPS any entry the two sides verified
+# under different inputs, so it re-verifies rather than asserting a verdict
+# this tree never had. See tools/verify/ledger_merge.py for the install line.
+verification_ledger.json merge=mathfin-ledger

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Block a push to main whose ledger does not describe the tree being pushed.
+#
+# Why this exists: main has no branch protection, so a locally-created merge
+# commit reaches main without any pre-merge CI. On 2026-08-07 the #173 merge
+# did exactly that — PR CI had validated the PR head and main separately, never
+# their merge — and main landed red on a dropped ledger row.
+#
+# Deliberately stdlib + host-side only (no docker, ~1s): this catches the class
+# that actually escaped, and a hook slow enough to be bypassed is worse than no
+# hook. The full suite still runs in CI.
+#
+# Enable per clone (git config is not versioned):
+#     git config core.hooksPath .githooks
+# Skip once, deliberately:  git push --no-verify
+
+pushing_main=0
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+    case "$remote_ref" in refs/heads/main) pushing_main=1 ;; esac
+done
+[ "$pushing_main" -eq 1 ] || exit 0
+
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! python3 -m tools.verify.ledger status >/tmp/mathfin-prepush.$$ 2>&1; then
+    echo "pre-push: BLOCKED — the verification ledger does not describe this tree." >&2
+    tail -12 /tmp/mathfin-prepush.$$ >&2
+    echo "" >&2
+    echo "  stale rows  -> python3 -m tools.verify.ledger verify   (daemon up)" >&2
+    echo "  missing rows-> usually a merge dropped them; same command re-adds" >&2
+    echo "  deliberate  -> git push --no-verify" >&2
+    rm -f /tmp/mathfin-prepush.$$
+    exit 1
+fi
+rm -f /tmp/mathfin-prepush.$$
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,25 @@ python3 -m tools.verify.ledger status      # fresh/stale/missing (exit 1 if not 
 python3 -m tools.verify.ledger verify      # re-verify just the stale entries (daemon must be up)
 ```
 
+**The ledger is derived state, and merges it.** It is a flat `{id: row}` map, so
+git's default text merge combines two branches silently whenever they touch
+different regions — which on 2026-08-07 dropped a row during the #173 merge and
+put main red. `.gitattributes` routes it through `tools/verify/ledger_merge.py`,
+which unions disjoint verifications and DROPS any entry the two sides verified
+under different inputs so it re-verifies rather than asserting a verdict this
+tree never had. Two setup lines per clone, since git config is not versioned:
+
+```bash
+git config merge.mathfin-ledger.name "semantic merge for verification_ledger.json"
+git config merge.mathfin-ledger.driver "python3 tools/verify/ledger_merge.py %O %A %B %L %P"
+git config core.hooksPath .githooks   # pre-push: blocks a red ledger reaching main
+```
+
+Without them git falls back to the text merge, so `tests/test_ledger.py` stays the
+real safety net; the driver is what keeps it from firing. **main has no branch
+protection**, so a locally-created merge commit reaches it with no pre-merge CI —
+that is how #173 landed red. The `pre-push` hook covers that gap host-side in ~1s.
+
 Host-side, stdlib-only; the Lean work happens in the lean-repl daemon. This
 replaces blanket re-verification sweeps — only entries whose inputs changed
 ever re-run. Benchmark snippets that import a MathFin module do NOT

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -253,6 +253,39 @@ for the entries already past.
 
 ---
 
+## A merge left the ledger describing a tree nobody verified
+
+**Symptom:** right after a `git merge` or rebase, `ledger status` reports MISSING rows, or
+`tests/test_ledger.py::test_every_benchmark_entry_has_a_ledger_row` fails naming an entry that
+plainly exists in `benchmarks/`.
+
+**Cause:** `verification_ledger.json` is a flat `{id: row}` map. Git's default text merge combines
+two branches without conflicting whenever they touch different regions of the file, so a row can be
+dropped (or carried across) with no conflict marker and no warning. Observed 2026-08-07: the #173
+merge dropped `mf-vnm-expected-utility` while the corpus side kept the entry, and main went red.
+
+Note the ledger is self-healing against *wrong* rows — `classify` recomputes every input hash from
+the working tree, so a carried-over row whose inputs changed reports STALE. The damaging case is a
+**missing** row, and the gates catch that too. What failed was not detection but *timing*: main has
+no branch protection, so a locally-created merge commit reached it without pre-merge CI.
+
+**Fix:**
+```bash
+# one-time per clone — git config is not versioned
+git config merge.mathfin-ledger.name "semantic merge for verification_ledger.json"
+git config merge.mathfin-ledger.driver "python3 tools/verify/ledger_merge.py %O %A %B %L %P"
+git config core.hooksPath .githooks
+
+# after any merge that touched benchmarks/ or MathFin/
+python3 -m tools.verify.ledger status
+python3 -m tools.verify.ledger verify   # daemon up; re-runs only what is stale/missing
+```
+`.gitattributes` already routes the file at the driver; the two `git config` lines are what make it
+take effect. Treat the ledger as regenerable output — if a merge touched it, re-derive rather than
+hand-resolve.
+
+---
+
 ## CI fails on `test_values.py` after a benchmark edit
 
 **Symptom:** `tests/test_values.py` fails with "stale AxiomAuditGen" or a

--- a/tests/test_ledger_merge.py
+++ b/tests/test_ledger_merge.py
@@ -1,0 +1,68 @@
+"""The semantic merge driver for ``verification_ledger.json``.
+
+Regression cover for 2026-08-07: the merge of PR #173 into main auto-merged the
+ledger textually and dropped the row for ``mf-vnm-expected-utility`` while the
+corpus side kept the entry, so main went red on
+``test_every_benchmark_entry_has_a_ledger_row``. The driver in
+``tools/verify/ledger_merge.py`` makes that merge semantic.
+
+The rule under test is that a genuine disagreement DROPS the row rather than
+picking a side. Dropping is recoverable and honest — ``ledger status`` recomputes
+every hash from the tree, so the entry reports MISSING and re-verifies. Picking a
+side would assert a verification the merged tree never had.
+"""
+
+from tools.verify.ledger_merge import merge_entries
+
+
+def row(h: str) -> dict:
+    return {"input_hash": h, "date": "2026-08-07"}
+
+
+def test_disjoint_additions_both_survive() -> None:
+    """The #173 regression: each side adds a different entry; neither is lost."""
+    base = {"a": row("h_a")}
+    ours = {"a": row("h_a"), "X": row("h_x")}
+    theirs = {"a": row("h_a"), "mf-vnm-expected-utility": row("h_v")}
+    merged, dropped = merge_entries(base, ours, theirs)
+    assert set(merged) == {"a", "X", "mf-vnm-expected-utility"}
+    assert dropped == []
+
+
+def test_same_hash_on_both_sides_is_kept() -> None:
+    base: dict = {}
+    ours = {"a": row("same")}
+    theirs = {"a": row("same")}
+    merged, dropped = merge_entries(base, ours, theirs)
+    assert merged["a"]["input_hash"] == "same"
+    assert dropped == []
+
+
+def test_conflicting_hashes_drop_the_row_rather_than_guess() -> None:
+    """Neither verdict describes the merged tree, so the entry must re-verify."""
+    base = {"a": row("h_old")}
+    ours = {"a": row("h_ours")}
+    theirs = {"a": row("h_theirs")}
+    merged, dropped = merge_entries(base, ours, theirs)
+    assert "a" not in merged, "a contested row must not survive with either hash"
+    assert dropped == ["a"]
+
+
+def test_deletion_on_one_side_is_respected() -> None:
+    """An entry removed from the corpus must not be resurrected by the merge."""
+    base = {"gone": row("h"), "kept": row("h2")}
+    ours = {"kept": row("h2")}                      # deleted `gone`
+    theirs = {"gone": row("h"), "kept": row("h2")}  # untouched
+    merged, _ = merge_entries(base, ours, theirs)
+    assert "gone" not in merged
+    assert "kept" in merged
+
+
+def test_addition_is_distinguished_from_survival_of_a_deletion() -> None:
+    """Absent-from-base means added; absent-from-base on both sides unions."""
+    base: dict = {}
+    ours = {"new_ours": row("h1")}
+    theirs = {"new_theirs": row("h2")}
+    merged, dropped = merge_entries(base, ours, theirs)
+    assert set(merged) == {"new_ours", "new_theirs"}
+    assert dropped == []

--- a/tools/verify/ledger_merge.py
+++ b/tools/verify/ledger_merge.py
@@ -1,0 +1,106 @@
+"""Git merge driver for ``verification_ledger.json``.
+
+The ledger is a flat ``{"entries": {id: row}}`` map, so git's default text merge
+combines two branches without conflicting whenever they touch different regions
+of the file. That is silent and occasionally wrong: on 2026-08-07 the merge of
+PR #173 into main dropped the row for ``mf-vnm-expected-utility`` while the
+corpus side kept the entry, and main went red on
+``tests/test_ledger.py::test_every_benchmark_entry_has_a_ledger_row``.
+
+The ledger is *derived state*, not content, so the right merge is semantic
+rather than textual:
+
+* an id on only one side          -> take it
+* an id on both, same input_hash  -> take it (pick the earlier verification)
+* an id on both, DIFFERENT hashes -> **drop it**
+* an id deleted on one side       -> respect the deletion
+
+Dropping is always safe and never a guess. ``ledger status`` recomputes every
+input hash from the working tree, so a dropped row reports MISSING, fails the
+gate loudly, and ``ledger verify`` re-runs exactly that entry. Keeping either
+side would instead assert a verification that this merged tree never had. The
+failure mode is therefore "one entry re-verifies", not "the ledger lies".
+
+Install (per clone, since git config is not versioned)::
+
+    git config merge.mathfin-ledger.name "semantic merge for verification_ledger.json"
+    git config merge.mathfin-ledger.driver "python3 tools/verify/ledger_merge.py %O %A %B %L %P"
+
+``.gitattributes`` already routes the file here. Without the config git falls
+back to the default text merge — which is why ``tests/test_ledger.py`` remains
+the real safety net and this driver is the thing that keeps it from firing.
+
+Pure stdlib; runs on the host during a merge.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _load(path: str) -> dict:
+    text = Path(path).read_text(encoding="utf-8")
+    return json.loads(text) if text.strip() else {"_meta": {}, "entries": {}}
+
+
+def merge_entries(base: dict, ours: dict, theirs: dict) -> tuple[dict, list[str]]:
+    """Semantic three-way merge of the id -> row maps. Returns (merged, dropped)."""
+    merged: dict = {}
+    dropped: list[str] = []
+    for key in sorted(set(ours) | set(theirs)):
+        in_ours, in_theirs = key in ours, key in theirs
+        if in_ours and in_theirs:
+            if ours[key].get("input_hash") == theirs[key].get("input_hash"):
+                merged[key] = ours[key]
+            else:
+                # both sides verified this entry under different inputs; neither
+                # verdict describes the merged tree, so make it re-verify
+                dropped.append(key)
+        elif in_ours:
+            # kept only if the other side did not delete it relative to the base
+            if key not in base:
+                merged[key] = ours[key]
+        else:
+            if key not in base:
+                merged[key] = theirs[key]
+    return merged, dropped
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 4:
+        print("usage: ledger_merge.py %O %A %B [%L %P]", file=sys.stderr)
+        return 2
+    base_path, ours_path, theirs_path = argv[1], argv[2], argv[3]
+    try:
+        base, ours, theirs = _load(base_path), _load(ours_path), _load(theirs_path)
+    except json.JSONDecodeError as exc:
+        # a malformed side means we cannot reason semantically; let git conflict
+        print(f"ledger_merge: cannot parse a side ({exc}) — falling back to conflict",
+              file=sys.stderr)
+        return 1
+
+    merged, dropped = merge_entries(
+        base.get("entries", {}), ours.get("entries", {}), theirs.get("entries", {}))
+
+    out = dict(ours)
+    out["entries"] = merged
+    # _meta describes the sweep that produced the file; after a merge it
+    # describes neither side, so carry ours and let the next sweep rewrite it.
+    Path(ours_path).write_text(
+        json.dumps(out, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if dropped:
+        print(f"ledger_merge: {len(dropped)} entr{'y' if len(dropped) == 1 else 'ies'} "
+              f"verified differently on each side — dropped so they re-verify: "
+              f"{', '.join(dropped[:8])}{' …' if len(dropped) > 8 else ''}",
+              file=sys.stderr)
+    print(f"ledger_merge: merged {len(merged)} rows; run "
+          f"`python3 -m tools.verify.ledger status` before trusting this tree",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
`verification_ledger.json` is a flat `{id: row}` map, so git's default text merge combines two
branches without conflicting whenever they touch different regions. on 2026-08-07 the #173 merge
dropped the row for `mf-vnm-expected-utility` while the corpus side kept the entry, and main landed
red on `test_every_benchmark_entry_has_a_ledger_row`.

## what i got wrong first, since it changed the fix

i wrote this up as "a row can survive a merge whose inputs changed on the other side". **that case
does not exist.** `ledger.classify` recomputes every input hash from the working tree and compares it
to the recorded one, so a carried-over row reports STALE. the ledger is *self-healing* against wrong
rows; only a MISSING row is damaging, and `test_ledger` catches that too.

so detection was never the gap. **timing was.** main has no branch protection, so a locally-created
merge commit — which is what a fork PR that cannot be maintainer-edited produces — reaches main with
no pre-merge CI. PR CI had validated the PR head and main separately, never their merge.

## the fix

**`tools/verify/ledger_merge.py`** + `.gitattributes` — a semantic merge driver:

| case | result |
|---|---|
| id on one side only | take it |
| id on both, same `input_hash` | take it |
| id on both, **different** hashes | **drop it** |
| id deleted on one side | respect the deletion |

dropping is never a guess. a dropped row reports MISSING and re-verifies; keeping either side would
assert a verification the merged tree never had. the failure mode becomes "one entry re-runs" instead
of "the ledger lies".

**`.githooks/pre-push`** — blocks a push to main whose `ledger status` is not clean. stdlib,
host-side, ~1s, no docker: it catches the class that actually escaped, and a hook slow enough to get
bypassed is worse than no hook. `--no-verify` to override.

both need per-clone `git config` because git config is not versioned, so `tests/test_ledger.py`
remains the real safety net and the driver is what keeps it from firing. setup lines are in
`CLAUDE.md` and `docs/troubleshooting.md`.

## verification

not just unit-tested. the driver was run against the **actual #173 shape** — each side adding a
different entry — end to end through a real `git merge` in a scratch repo with `.gitattributes`
wired: `mf-vnm` survives, `X` survives, the contested row drops. the hook was negative-controlled by
deleting a ledger row and confirming it blocks with a useful message, then confirming it passes on a
clean tree and skips non-main pushes.

5 new tests, 48 total. ledger 353 fresh / 0 stale.

## still open

**main has no required status checks.** branch protection would close the root cause rather than the
symptom, but it changes how every push and every PR lands — including the autoformalization
pipeline's — so it is your call, not something to slip into a fix.
