### PR TITLE
docs(labels): three status labels are machine-written now, and nothing said so

### DIFF
--- a/docs/issue-labels.md
+++ b/docs/issue-labels.md
@@ -60,15 +60,52 @@ cross-cutting.
 
 ## Status labels
 
-| Label | Use for |
+| Label | Use for | Written by |
+|---|---|---|
+| `status:needs-triage` | New issue that has not been classified yet. | human |
+| `status:needs-info` | Waiting on clarification before work should start. | human |
+| `status:ready` | Scoped enough for a contributor to pick up. | human, or the pipeline on release |
+| `status:in-progress` | Someone is actively working on it. | human, or the pipeline on seed |
+| `status:blocked-upstream` | Blocked on Mathlib, BrownianMotion, or another external project. | human |
+| `status:blocked-design` | Blocked on a modeling, theorem-shape, or architecture decision. | human |
+| `status:review` | PR exists and maintainer review is the next step. | human, or the pipeline on PR |
+
+### Three of these are machine-written
+
+The autoformalization pipeline in `formal-foundry` used to only READ this backlog.
+It kept its own private record of which issues it had already worked, that record
+drifted from reality, and the pipeline re-drafted work it had already queued. The
+fix was to stop keeping a private record: **the issue is now the state machine, and
+everything the pipeline stores locally is a cache of it.**
+
+So the pipeline moves an issue between three of the seven statuses:
+
+| transition | when |
 |---|---|
-| `status:needs-triage` | New issue that has not been classified yet. |
-| `status:needs-info` | Waiting on clarification before work should start. |
-| `status:ready` | Scoped enough for a contributor to pick up. |
-| `status:in-progress` | Someone is actively working on it. |
-| `status:blocked-upstream` | Blocked on Mathlib, BrownianMotion, or another external project. |
-| `status:blocked-design` | Blocked on a modeling, theorem-shape, or architecture decision. |
-| `status:review` | PR exists and maintainer review is the next step. |
+| `status:ready` → `status:in-progress` | a gated Lean stub for the issue is staged in the pipeline's queue |
+| `status:in-progress` → `status:review` | a PR closing the issue has been opened |
+| back to `status:ready` | the PR was closed unmerged, or the staged stub was retired |
+| → closed | GitHub closes it when the PR merges |
+
+Three consequences worth knowing when you triage:
+
+- **A label may move without a human touching it.** If an issue you filed is
+  suddenly `status:in-progress` with nobody assigned, a machine drafted a statement
+  for it. Nothing has been merged — see below.
+- **The four other statuses are yours alone, and the pipeline will not overrule
+  them.** `status:blocked-design` in particular looks identical to "ready" from the
+  machine's side (no PR, no stub), so it is explicitly excluded: parking an issue
+  there reliably keeps it out of the pipeline. An issue with *no* status label is
+  likewise never promoted — the pipeline repairs its own writes, it does not decide
+  what is worth proving.
+- **`status:review` still means a human reviews it.** Scout-not-author is unchanged:
+  a machine may draft a statement and find a proof, and a person refines and merges
+  it. No label transition here is an approval of anything.
+
+Label writes are best-effort by design — a failed write must never fail a pipeline
+run — so a stale status is possible. The pipeline re-derives all three from the
+observable facts (open PRs, staged stubs) at the start of each run, so a stale one
+corrects itself rather than needing a manual fix.
 
 ## Triage examples
 


### PR DESCRIPTION
The autoformalization pipeline in `formal-foundry` used to only READ this backlog. It kept a private record of which issues it had already worked, that record drifted from reality, and it re-drafted work it had already queued — six staged stubs whose issues all still said `status:ready`.

The fix ([formal-foundry@491db7e](https://github.com/formal-applied-math/formal-foundry/commit/491db7e)) was to stop keeping a private record: **the issue is the state machine, and everything the pipeline stores locally is a cache of it.** That means the pipeline now *writes* three of the seven `status:*` labels — and a maintainer reading this doc had no way to know a label could move without a human touching it.

### What changes here

Doc only. A **Written by** column on the status table, plus a section covering the three things that actually change for triage:

- **A label may move with nobody assigned.** If an issue you filed goes `status:in-progress` on its own, a machine drafted a Lean statement for it.
- **The other four statuses are human-only and are never overruled.** `status:blocked-design` matters most: it looks identical to "ready" from the machine's side — no PR, no stub — so it is excluded explicitly, and parking an issue there reliably keeps it out of the pipeline. An issue with *no* status label is likewise never promoted; the pipeline repairs its own writes, it does not decide what is worth proving.
- **`status:review` still means a human reviews it.** Scout-not-author is unchanged. No transition here is an approval of anything.

It also records that the writes are best-effort by design (a failed label write must never fail a pipeline run) and that all three are re-derived from the observable facts — open PRs, staged stubs — at the start of every run, so a stale status corrects itself rather than needing a manual fix.

### Transitions, for reference

| transition | when |
|---|---|
| `status:ready` → `status:in-progress` | a gated Lean stub for the issue is staged in the pipeline's queue |
| `status:in-progress` → `status:review` | a PR closing the issue has been opened |
| back to `status:ready` | the PR was closed unmerged, or the staged stub was retired |
| → closed | GitHub closes it when the PR merges |

The label descriptions in the bootstrap `gh label create` commands are unchanged, so the table still mirrors what actually gets set on GitHub.

`tests/` is green (50 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
