### PR TITLE
fix(contracts): close the Adapted-to-pricing seam, and unbreak containerised builds

### DIFF
--- a/MathFin/Contracts/Adapted.lean
+++ b/MathFin/Contracts/Adapted.lean
@@ -19,9 +19,18 @@ observation the payoff makes is dated no later than `u`
 (`Payoff.measurable_eval_of_obsTimes_le`). That second fact is what will make a
 `Payoff` a legitimate stochastic-integral integrand: it is the adaptedness
 hypothesis a future integral rung against a filtered probability space will
-need. **No theorem in the tower consumes it yet** — `Contracts/Pricing.lean`
-integrates only against a fixed measure `Q`, never against a filtration, so it
-has no adaptedness hypothesis to discharge with this file's results.
+need. **`measurable_eval_of_obsTimes_le` has no consumer yet** —
+`Contracts/Pricing.lean` integrates only against a fixed measure `Q`, never
+against a filtration, so it has no adaptedness hypothesis to discharge with
+this file's results.
+
+`Payoff.aemeasurable_eval` weakens `measurable_eval`'s hypothesis from
+`Measurable` to `AEMeasurable` — the strength the tower's own pricing
+hypotheses actually supply (`BSCallHyp`'s `Z_law : HasLaw Z (gaussianReal 0 1)
+Q` gives only `AEMeasurable Z`, never `Measurable Z`). Unlike its two
+siblings, it **is** consumed: `Contracts/CappedCall.lean`'s
+`integrable_europeanCall_pathPV` calls it directly, in place of hand-rolling
+the same measurability argument against `bsAssets`.
 
 ## Main definitions
 
@@ -44,6 +53,15 @@ has no adaptedness hypothesis to discharge with this file's results.
   into one by the corresponding `Measurable.add`/`.sub`/`.mul`/`.max`/`.min`
   lemma, or `Measurable.ite` composed with `measurableSet_lt` for
   `indicatorLt`.
+* `Payoff.aemeasurable_eval` — the same conclusion as `measurable_eval`, from
+  the weaker hypothesis that each `X i t` is only `AEMeasurable`. Built from
+  `measurable_eval` applied to measurable representatives `(hX i t).mk (X i
+  t)`, transported across the a.e. equality `e.eval X =ᵐ[μ] e.eval X'` proved
+  by a second structural induction (each `obs` leaf contributes
+  `AEMeasurable.ae_eq_mk`; the six binary constructors combine two a.e. facts
+  by `filter_upwards`) — not a direct induction into `AEMeasurable`, whose
+  `indicatorLt` case would need a `NullMeasurableSet` this route avoids
+  producing.
 
 ## Source
 
@@ -101,6 +119,31 @@ theorem Payoff.measurable_eval (e : Payoff ι) (X : ι → ℝ≥0 → Ω → �
   | indicatorLt a b ha hb =>
       exact Measurable.ite (measurableSet_lt ha hb) measurable_const measurable_const
 
+/-- Evaluating a payoff against an a.e.-measurable model is a.e.-measurable: the strength a
+consumer whose model only satisfies `AEMeasurable` (e.g. `HasLaw.aemeasurable`, never
+`Measurable`) actually has. Built from `measurable_eval` on each model coordinate's measurable
+representative `(hX i t).mk (X i t)`, transported across its a.e. equality with the original —
+not a second induction into `AEMeasurable`, whose `indicatorLt` case wants a
+`NullMeasurableSet` awkward to produce here. -/
+theorem Payoff.aemeasurable_eval {μ : Measure Ω} (e : Payoff ι) (X : ι → ℝ≥0 → Ω → ℝ)
+    (hX : ∀ i t, AEMeasurable (X i t) μ) :
+    AEMeasurable (fun ω ↦ e.eval (fun i t ↦ X i t ω)) μ := by
+  let X' : ι → ℝ≥0 → Ω → ℝ := fun i t ↦ (hX i t).mk (X i t)
+  have heq (e : Payoff ι) : (fun ω ↦ e.eval (fun i t ↦ X i t ω))
+      =ᵐ[μ] fun ω ↦ e.eval (fun i t ↦ X' i t ω) := by
+    induction e with
+    | const c => exact .of_forall fun _ ↦ rfl
+    | obs i t => exact (hX i t).ae_eq_mk
+    | add a b ha hb => filter_upwards [ha, hb] with ω hae hbe; simp only [Payoff.eval, hae, hbe]
+    | sub a b ha hb => filter_upwards [ha, hb] with ω hae hbe; simp only [Payoff.eval, hae, hbe]
+    | mul a b ha hb => filter_upwards [ha, hb] with ω hae hbe; simp only [Payoff.eval, hae, hbe]
+    | max a b ha hb => filter_upwards [ha, hb] with ω hae hbe; simp only [Payoff.eval, hae, hbe]
+    | min a b ha hb => filter_upwards [ha, hb] with ω hae hbe; simp only [Payoff.eval, hae, hbe]
+    | indicatorLt a b ha hb =>
+        filter_upwards [ha, hb] with ω hae hbe; simp only [Payoff.eval, hae, hbe]
+  have hX'meas : ∀ i t, Measurable (X' i t) := fun i t ↦ (hX i t).measurable_mk
+  exact (Payoff.measurable_eval e X' hX'meas).aemeasurable.congr (heq e).symm
+
 /-- If a hypothesis `∀ t ∈ l₁ ++ l₂, t ≤ u` holds, it holds on each summand
 separately. Stated on the raw list (rather than on `Payoff.add`'s `obsTimes`)
 so it is reusable, unconditionally, across all six binary constructors. -/
@@ -114,8 +157,10 @@ private theorem obsTimes_append_le {u : ℝ≥0} {l₁ l₂ : List ℝ≥0}
 `𝓕 u`, as soon as every time the payoff observes is dated no later than `u`.
 This is the theorem that will make a `Payoff` a legitimate stochastic-integral
 integrand — the adaptedness hypothesis a future integral rung will need.
-No theorem in the tower consumes it yet: `Contracts/Pricing.lean` integrates
-against a fixed measure, not a filtration. -/
+Still has no consumer: `Contracts/Pricing.lean` integrates against a fixed
+measure, not a filtration, and unlike `measurable_eval`'s a.e. counterpart
+above, no `Payoff` in the tower yet needs an argument observed before a fixed
+time rather than a fixed measure. -/
 theorem Payoff.measurable_eval_of_obsTimes_le
     {𝓕 : Filtration ℝ≥0 mΩ} {u : ℝ≥0} (e : Payoff ι) (X : ι → ℝ≥0 → Ω → ℝ)
     (hX : ∀ i t, Measurable[𝓕 t] (X i t))

--- a/MathFin/Contracts/BlackScholes.lean
+++ b/MathFin/Contracts/BlackScholes.lean
@@ -37,6 +37,8 @@ the existing theorem.
 
 * `bsAssets` — the single-asset Black–Scholes model as a model map `Unit → ℝ≥0 → Ω → ℝ`,
   constant in `t` and equal to `bsTerminal` at every time.
+* `europeanCallPayoff` — the call's payoff data on its own, so `CappedCall.lean` can build
+  against exactly this term rather than a second copy of it.
 * `europeanCall`, `europeanPut`, `digitalCall` — the three reified `Contract Unit`s.
 
 ## Main results
@@ -85,9 +87,15 @@ path-dependent instance needs the full GBM path and is deferred. -/
 noncomputable def bsAssets (S_0 r σ T : ℝ) (Z : Ω → ℝ) : Unit → ℝ≥0 → Ω → ℝ :=
   fun _ _ ω ↦ bsTerminal S_0 r σ T (Z ω)
 
+/-- The European call payoff `max (S_T - K) 0`, on its own so a consumer outside this file
+(`CappedCall.lean`'s measurability argument) can reference the same term rather than
+re-spelling it. -/
+noncomputable def europeanCallPayoff (K : ℝ) (T : ℝ≥0) : Payoff Unit :=
+  .max (.sub (.obs () T) (.const K)) (.const 0)
+
 /-- The reified European call: pays `max (S_T - K) 0` at maturity `T`. -/
 noncomputable def europeanCall (K : ℝ) (T : ℝ≥0) : Contract Unit :=
-  .pay T (.max (.sub (.obs () T) (.const K)) (.const 0))
+  .pay T (europeanCallPayoff K T)
 
 /-- The reified European put: pays `max (K - S_T) 0` at maturity `T`. -/
 noncomputable def europeanPut (K : ℝ) (T : ℝ≥0) : Contract Unit :=

--- a/MathFin/Contracts/CappedCall.lean
+++ b/MathFin/Contracts/CappedCall.lean
@@ -5,6 +5,7 @@ Authors: Raphael Coelho
 -/
 module
 
+public import MathFin.Contracts.Adapted
 public import MathFin.Contracts.BlackScholes
 public import MathFin.BlackScholes.CappedCall
 public import MathFin.Foundations.BrownianMartingale
@@ -40,7 +41,9 @@ via `cappedCall_eq_bull_spread`.
   an integral. The discounted payoff's integrability, which `Contract.value_both` needs, is
   discharged internally (`integrable_europeanCall_pathPV`) by domination against the
   terminal asset price, whose exponential moment is `integrable_exp_mul_of_hasLaw`'s
-  Gaussian MGF transfer.
+  Gaussian MGF transfer; the payoff's measurability step is `Adapted.lean`'s
+  `Payoff.aemeasurable_eval`, applied to the reified `europeanCall` payoff rather than
+  hand-rolled against `bsTerminal` directly.
 
 ## Source
 
@@ -83,7 +86,10 @@ noncomputable def cappedCall (K₁ K₂ : ℝ) (T : ℝ≥0) : Contract Unit :=
 /-- The discounted payoff of a reified European call is integrable under `BSCallHyp`: it is
 dominated by the terminal asset price `bsTerminal`, itself integrable via the Gaussian MGF
 transfer `integrable_exp_mul_of_hasLaw`. This is what lets `value_cappedCall` below drop the
-integrability hypotheses `Contract.value_both` would otherwise need supplied by hand. -/
+integrability hypotheses `Contract.value_both` would otherwise need supplied by hand.
+Measurability of the payoff comes from `Payoff.aemeasurable_eval` applied to `europeanCall`'s
+own payoff data, not from a bespoke argument against `bsTerminal`: `BSCallHyp`'s `Z_law`
+supplies only `AEMeasurable Z`, which is exactly the hypothesis strength that theorem wants. -/
 private theorem integrable_europeanCall_pathPV {Q : Measure Ω} [IsProbabilityMeasure Q]
     {S_0 K r σ : ℝ} {T : ℝ≥0} {Z : Ω → ℝ} (h : BSCallHyp Q S_0 K r σ T Z) :
     Integrable (fun ω ↦ (europeanCall K T).pathPV
@@ -98,10 +104,14 @@ private theorem integrable_europeanCall_pathPV {Q : Measure Ω} [IsProbabilityMe
     exact (integrable_exp_mul_of_hasLaw hZ (σ * Real.sqrt T)).const_mul _
   have h_asset_pos (ω : Ω) : 0 < bsTerminal S_0 r σ T (Z ω) :=
     mul_pos hS_0 (Real.exp_pos _)
+  have hX : ∀ (i : Unit) (t : ℝ≥0), AEMeasurable (bsAssets S_0 r σ T Z i t) Q :=
+    fun _ _ ↦ h_asset_meas.comp_aemeasurable hZ.aemeasurable
   have h_payoff_meas : AEStronglyMeasurable
-      (fun ω ↦ max (bsTerminal S_0 r σ T (Z ω) - K) 0) Q :=
-    ((h_asset_meas.sub measurable_const).max measurable_const).comp_aemeasurable
-      hZ.aemeasurable |>.aestronglyMeasurable
+      (fun ω ↦ max (bsTerminal S_0 r σ T (Z ω) - K) 0) Q := by
+    have h := (Payoff.aemeasurable_eval
+      (Payoff.max (Payoff.sub (Payoff.obs () T) (Payoff.const K)) (Payoff.const 0))
+      (bsAssets S_0 r σ T Z) hX).aestronglyMeasurable
+    simpa only [Payoff.eval, bsAssets] using h
   have h_payoff_int : Integrable (fun ω ↦ max (bsTerminal S_0 r σ T (Z ω) - K) 0) Q := by
     refine h_asset_int.mono' h_payoff_meas (ae_of_all _ fun ω ↦ ?_)
     rw [Real.norm_eq_abs, abs_of_nonneg (le_max_right _ _)]

--- a/MathFin/Contracts/CappedCall.lean
+++ b/MathFin/Contracts/CappedCall.lean
@@ -109,16 +109,16 @@ private theorem integrable_europeanCall_pathPV {Q : Measure Ω} [IsProbabilityMe
   have h_payoff_meas : AEStronglyMeasurable
       (fun ω ↦ max (bsTerminal S_0 r σ T (Z ω) - K) 0) Q := by
     have h := (Payoff.aemeasurable_eval
-      (Payoff.max (Payoff.sub (Payoff.obs () T) (Payoff.const K)) (Payoff.const 0))
+      (europeanCallPayoff K T)
       (bsAssets S_0 r σ T Z) hX).aestronglyMeasurable
-    simpa only [Payoff.eval, bsAssets] using h
+    simpa only [europeanCallPayoff, Payoff.eval, bsAssets] using h
   have h_payoff_int : Integrable (fun ω ↦ max (bsTerminal S_0 r σ T (Z ω) - K) 0) Q := by
     refine h_asset_int.mono' h_payoff_meas (ae_of_all _ fun ω ↦ ?_)
     rw [Real.norm_eq_abs, abs_of_nonneg (le_max_right _ _)]
     calc max (bsTerminal S_0 r σ T (Z ω) - K) 0
         ≤ max (bsTerminal S_0 r σ T (Z ω)) 0 := max_le_max (by linarith) le_rfl
       _ = bsTerminal S_0 r σ T (Z ω) := max_eq_left (h_asset_pos ω).le
-  simp only [europeanCall, Contract.pathPV, Contract.cashflows, Payoff.eval,
+  simp only [europeanCall, europeanCallPayoff, Contract.pathPV, Contract.cashflows, Payoff.eval,
     scenarioAt, bsAssets, List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
   exact h_payoff_int.const_mul _
 
@@ -130,8 +130,8 @@ theorem cappedCall_payoff_eq {K₁ K₂ : ℝ} (h : K₁ ≤ K₂) {T : ℝ≥0}
     (s : Scenario Unit) :
     (cappedCall K₁ K₂ T).pathPV (fun _ ↦ 1) s
       = min (max (s () T - K₁) 0) (K₂ - K₁) := by
-  simp only [cappedCall, Contract.pathPV, Contract.cashflows, europeanCall, Payoff.eval,
-    List.map_append, List.map_cons, List.map_nil, List.sum_append,
+  simp only [cappedCall, Contract.pathPV, Contract.cashflows, europeanCall, europeanCallPayoff,
+    Payoff.eval, List.map_append, List.map_cons, List.map_nil, List.sum_append,
     List.sum_cons, List.sum_nil, one_mul, add_zero]
   linarith [MathFin.cappedCall_eq_bull_spread (s () T) K₁ K₂ h]
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -91,6 +91,13 @@ services:
       # into the container with no rebuild.
       - ../MathFin:/app/MathFin
       - ../MathFin.lean:/app/MathFin.lean
+      # Palomar registry targets. `lakefile.lean` declares `lean_lib Challenge`
+      # and `lean_lib Solution` (added on main 2026-08-20), so without these two
+      # mounts every containerised `lake build` fails with "some modules have bad
+      # imports" — the lakefile is mounted but the files it names are not. CI is
+      # unaffected because it checks out the whole repo.
+      - ../Challenge.lean:/app/Challenge.lean
+      - ../Solution.lean:/app/Solution.lean
       - ../lakefile.lean:/app/lakefile.lean
       - ../lake-manifest.json:/app/lake-manifest.json
       - ../lean-toolchain:/app/lean-toolchain
@@ -139,6 +146,13 @@ services:
       - ../tools:/app/tools:ro
       - ../MathFin:/app/MathFin
       - ../MathFin.lean:/app/MathFin.lean
+      # Palomar registry targets. `lakefile.lean` declares `lean_lib Challenge`
+      # and `lean_lib Solution` (added on main 2026-08-20), so without these two
+      # mounts every containerised `lake build` fails with "some modules have bad
+      # imports" — the lakefile is mounted but the files it names are not. CI is
+      # unaffected because it checks out the whole repo.
+      - ../Challenge.lean:/app/Challenge.lean
+      - ../Solution.lean:/app/Solution.lean
       - ../lakefile.lean:/app/lakefile.lean
       - ../lake-manifest.json:/app/lake-manifest.json
       - ../lean-toolchain:/app/lean-toolchain

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -69,13 +69,15 @@ Report `reduced_core` and `placeholder` separately. **Spec-with-axiomatized-conc
 > 367).** Five new modules under `MathFin/Contracts/`, nine entries `mf-contract-*`. `Core.lean`
 > reifies a payoff as data — `Payoff ι` / `Contract ι` inductives over a **typed** underlying
 > index `ι` (`ι = Unit` for the single-asset instances below), not the inline lambda every other
-> payoff in the library is written as. `Adapted.lean` proves the reification pays for itself,
-> against a *future* rung: `Payoff.measurable_eval_of_obsTimes_le` is the adaptedness hypothesis
-> a `Payoff` will need to be a legitimate stochastic-integral integrand — `𝓕 u`-measurability
-> follows from every observation time in `obsTimes` (a syntactic, sufficient-not-necessary
-> over-approximation) being `≤ u`. **No theorem in this round consumes it yet** — `Pricing.lean`
-> integrates against a fixed measure, never a filtration, so it has nothing to discharge this
-> hypothesis against.
+> payoff in the library is written as. `Adapted.lean` proves the reification pays for itself:
+> `Payoff.measurable_eval_of_obsTimes_le` is the adaptedness hypothesis a `Payoff` will need to
+> be a legitimate stochastic-integral integrand — `𝓕 u`-measurability follows from every
+> observation time in `obsTimes` (a syntactic, sufficient-not-necessary over-approximation)
+> being `≤ u`; **it still has no consumer**, since `Pricing.lean` integrates against a fixed
+> measure, never a filtration. Its unconditional sibling `Payoff.measurable_eval` does have one
+> as of 2026-08-19: the a.e.-measurable variant `Payoff.aemeasurable_eval` is consumed by
+> `CappedCall.lean`'s `integrable_europeanCall_pathPV`, which needs exactly the `AEMeasurable`
+> strength `BSCallHyp` supplies rather than the `Measurable` this file originally proved.
 > `Pricing.lean` integrates `pathPV` against a measure into `Contract.value`, proves it linear
 > (`value_scale` unconditional, `value_both` needing both integrability hypotheses —
 > `integral_add` is false without them), and proves `value_deliverAsset` /

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -74,10 +74,11 @@ Report `reduced_core` and `placeholder` separately. **Spec-with-axiomatized-conc
 > be a legitimate stochastic-integral integrand — `𝓕 u`-measurability follows from every
 > observation time in `obsTimes` (a syntactic, sufficient-not-necessary over-approximation)
 > being `≤ u`; **it still has no consumer**, since `Pricing.lean` integrates against a fixed
-> measure, never a filtration. Its unconditional sibling `Payoff.measurable_eval` does have one
-> as of 2026-08-19: the a.e.-measurable variant `Payoff.aemeasurable_eval` is consumed by
-> `CappedCall.lean`'s `integrable_europeanCall_pathPV`, which needs exactly the `AEMeasurable`
-> strength `BSCallHyp` supplies rather than the `Measurable` this file originally proved.
+> measure, never a filtration. Its a.e.-measurable sibling `Payoff.aemeasurable_eval` does have
+> one as of 2026-08-19: `CappedCall.lean`'s `integrable_europeanCall_pathPV` calls it directly,
+> needing exactly the `AEMeasurable` strength `BSCallHyp` supplies rather than the `Measurable`
+> its own unconditional sibling `Payoff.measurable_eval` proves — that one stays consumed only
+> internally, by `aemeasurable_eval` on measurable representatives, not by `CappedCall.lean`.
 > `Pricing.lean` integrates `pathPV` against a measure into `Contract.value`, proves it linear
 > (`value_scale` unconditional, `value_both` needing both integrability hypotheses —
 > `integral_add` is false without them), and proves `value_deliverAsset` /

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1193,27 +1193,6 @@
       "input_hash": "d38d28f6e8d0ceb8c1b5d552729e1419adbc78c6d22bc0f3783b890bf8f57cf9",
       "verified_at_commit": "70acfe0"
     },
-    "mf-contract-digital-cash-or-nothing": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 5.6,
-      "input_hash": "01c8029fff751f4e7cb7ec6cac9ca28af649dd651b540df2fc69b1596cfe5e88",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-contract-european-call": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 3.8,
-      "input_hash": "337608907130cd66b1d112249b6cd1a290c28f4df0f1816e1141b01b6cf41885",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-contract-european-put": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 5.2,
-      "input_hash": "fab1e951de113811a94593000abe22d3e3a6af606ec391c10b1dc9475e17b18f",
-      "verified_at_commit": "70acfe0"
-    },
     "mf-contract-pathpv-both": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-08-20",

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1193,6 +1193,48 @@
       "input_hash": "d38d28f6e8d0ceb8c1b5d552729e1419adbc78c6d22bc0f3783b890bf8f57cf9",
       "verified_at_commit": "70acfe0"
     },
+    "mf-contract-capped-call": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 56.1,
+      "input_hash": "37d18ca53347fb0b51fe48aba60858628d73176e72c53feb7543f8e4f16b120a",
+      "verified_at_commit": "57078d1"
+    },
+    "mf-contract-capped-call-value": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 52.3,
+      "input_hash": "d356daf0107fd82138e8c64f43e5262dcd158ddffa1de6a46ba079331697834a",
+      "verified_at_commit": "57078d1"
+    },
+    "mf-contract-digital-cash-or-nothing": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 63.2,
+      "input_hash": "babbfb3d7f6ba23a64e30386b0a7f6f4a01a2ecd0eaf351d43e1142d957f5f9b",
+      "verified_at_commit": "57078d1"
+    },
+    "mf-contract-european-call": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 50.5,
+      "input_hash": "0e6a0b99e088cb264bde571ad31a43e2e4efa30f727196516a64bd82c50874ad",
+      "verified_at_commit": "57078d1"
+    },
+    "mf-contract-european-put": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 52.5,
+      "input_hash": "44c7fc981f54ef92efc1bd852d301e2457e4a1d6ba46e5d335784494ed5ae4f2",
+      "verified_at_commit": "57078d1"
+    },
+    "mf-contract-eval-adapted": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 3.9,
+      "input_hash": "74e1e98fc3aca2eaaa34982eccc0ecee5666f5d355c6f35777f57c25fd54da7a",
+      "verified_at_commit": "57078d1"
+    },
     "mf-contract-pathpv-both": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-08-20",
@@ -1240,6 +1282,55 @@
       "date": "2026-08-20",
       "elapsed_s": 5.6,
       "input_hash": "0fd33cceca96a3b51c23a0d839ad28a3233693e36fbf0a086d72702c68447562",
+      "verified_at_commit": "70acfe0"
+    },
+    "mf-crr-bs-call-convergence": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 4.7,
+      "input_hash": "138c2c3bb6e7aa81c7d2d2dc193a2a7fea1b8fec3c48bf25490afea14f8a6e28",
+      "verified_at_commit": "70acfe0"
+    },
+    "mf-crr-drift-limit": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 3.8,
+      "input_hash": "69382c5cbc4dc4ee5ea73b573e397fbe5cc602b4f94538f8499bcf5612395350",
+      "verified_at_commit": "70acfe0"
+    },
+    "mf-crr-drift-quotient": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 5.1,
+      "input_hash": "55bea7ba357557c7bff0b1689784e051b416e79b1fdcd771f396f898cde2ba70",
+      "verified_at_commit": "70acfe0"
+    },
+    "mf-crr-gaussian-limit": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 3.8,
+      "input_hash": "df5488e0aecd6d7ae5b1d25dde36521a6eef3d2631dcfb0206b661fcc1eff44f",
+      "verified_at_commit": "70acfe0"
+    },
+    "mf-crr-one-step-martingale": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 3.8,
+      "input_hash": "903606b5fcfb4542dde4ff5e26da814b5d51d27f1eb03a5174eb86dfc1c83c86",
+      "verified_at_commit": "70acfe0"
+    },
+    "mf-crr-prob-half": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 5.3,
+      "input_hash": "8746dbfd4f32b8896c1a521230b22e40cefefd56c4a3872139f501dd374cf8e3",
+      "verified_at_commit": "70acfe0"
+    },
+    "mf-crr-variance-limit": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-08-20",
+      "elapsed_s": 5.6,
+      "input_hash": "9ad48611acd647bf15521cb916f743293cc14fdec6f285268a2510f9747f485f",
       "verified_at_commit": "70acfe0"
     },
     "mf-cvar-rockafellar-uryasev": {

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1193,20 +1193,6 @@
       "input_hash": "d38d28f6e8d0ceb8c1b5d552729e1419adbc78c6d22bc0f3783b890bf8f57cf9",
       "verified_at_commit": "70acfe0"
     },
-    "mf-contract-capped-call": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 5.3,
-      "input_hash": "af21c4f288e54ee539bd6f337e0d20624d0cd4f920ddbcd63e30ea7f6fd29d5c",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-contract-capped-call-value": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 5.5,
-      "input_hash": "dd3a700f9cbac63482be246b2d035378dabae6fea8c3c5b667500a4c54d3f493",
-      "verified_at_commit": "70acfe0"
-    },
     "mf-contract-digital-cash-or-nothing": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-08-20",
@@ -1226,13 +1212,6 @@
       "date": "2026-08-20",
       "elapsed_s": 5.2,
       "input_hash": "fab1e951de113811a94593000abe22d3e3a6af606ec391c10b1dc9475e17b18f",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-contract-eval-adapted": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 5.2,
-      "input_hash": "5b7d5bf5b143bfd5a12284c5c41f1cb82d669976e0ef70c0ff16c6aa0918b858",
       "verified_at_commit": "70acfe0"
     },
     "mf-contract-pathpv-both": {
@@ -1282,55 +1261,6 @@
       "date": "2026-08-20",
       "elapsed_s": 5.6,
       "input_hash": "0fd33cceca96a3b51c23a0d839ad28a3233693e36fbf0a086d72702c68447562",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-crr-bs-call-convergence": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 4.7,
-      "input_hash": "138c2c3bb6e7aa81c7d2d2dc193a2a7fea1b8fec3c48bf25490afea14f8a6e28",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-crr-drift-limit": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 3.8,
-      "input_hash": "69382c5cbc4dc4ee5ea73b573e397fbe5cc602b4f94538f8499bcf5612395350",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-crr-drift-quotient": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 5.1,
-      "input_hash": "55bea7ba357557c7bff0b1689784e051b416e79b1fdcd771f396f898cde2ba70",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-crr-gaussian-limit": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 3.8,
-      "input_hash": "df5488e0aecd6d7ae5b1d25dde36521a6eef3d2631dcfb0206b661fcc1eff44f",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-crr-one-step-martingale": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 3.8,
-      "input_hash": "903606b5fcfb4542dde4ff5e26da814b5d51d27f1eb03a5174eb86dfc1c83c86",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-crr-prob-half": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 5.3,
-      "input_hash": "8746dbfd4f32b8896c1a521230b22e40cefefd56c4a3872139f501dd374cf8e3",
-      "verified_at_commit": "70acfe0"
-    },
-    "mf-crr-variance-limit": {
-      "benchmark_file": "mathematical_finance.json",
-      "date": "2026-08-20",
-      "elapsed_s": 5.6,
-      "input_hash": "9ad48611acd647bf15521cb916f743293cc14fdec6f285268a2510f9747f485f",
       "verified_at_commit": "70acfe0"
     },
     "mf-cvar-rockafellar-uryasev": {


### PR DESCRIPTION
Three commits. The first closes an architectural seam left open by #204; the second is its review's one finding; the third is an unrelated infrastructure fix that blocked the work and blocks anyone else building in a container on current `main`.

## 1. The seam — `Adapted.lean` was a cul-de-sac

#204's final whole-branch review found that `Payoff.measurable_eval` and `Payoff.measurable_eval_of_obsTimes_le` had **zero consumers**, while their docstrings and three docs advertised `Pricing.lean` as depending on them.

The cause was a strength mismatch. `measurable_eval` is stated in `Measurable`, but the one site needing payoff measurability — `integrable_europeanCall_pathPV` — has only `AEMeasurable`, from `BSCallHyp`'s `HasLaw Z` field. So it hand-rolled the argument. The measurability layer was stated one strength too high to be consumed by the pricing layer it existed to serve.

`Payoff.aemeasurable_eval` closes it: measurable representatives via `AEMeasurable.mk`, the existing `measurable_eval` applied to those, and a finite a.e. equality proved by structural induction over the eight `Payoff` constructors. `CappedCall.lean` now calls it; the hand-rolled chain is gone.

**`measurable_eval_of_obsTimes_le` remains genuinely unconsumed** — nothing integrates against a filtration yet — and the prose says which of the two gained a consumer rather than implying the file is now load-bearing.

## 2. Lift `europeanCallPayoff`

The call site re-spelled the payoff as a literal constructor tree instead of referencing the one inside `europeanCall`. Not unsound — a divergence fails to compile — but it reintroduced, one layer up, exactly the inline-payoff duplication this tower exists to eliminate, and made two docstrings ("applied to `europeanCall`'s own payoff data") only approximately true.

`europeanPut` and `digitalCall` are deliberately **not** extracted: nothing outside `BlackScholes.lean` references their payoffs, and extracting on speculation is the opposite error.

## 3. Mount the Palomar targets — this one affects everyone

`lakefile.lean` gained `lean_lib Challenge` and `lean_lib Solution`, but `docker-compose.yml` mounts neither file. The lakefile is mounted; the files it names are not. Every containerised `lake build` on current `main` fails:

```
error: Challenge: some modules have bad imports
error: Solution: some modules have bad imports
```

CI is unaffected because it checks out the whole repo — which is why this landed green.

The symptom is worse than the error reads: the daemon's startup build fails, it **serves anyway** against whatever oleans did build, and prints `READY`. Treating READY as green then gives unknown-namespace cascades with no visible cause.

With the mounts in place the build is green again and covers **9003 jobs** rather than 8999 — the difference being the two Palomar targets that previously could not build at all.

## Verification

`lake build MathFin && lake lint` exit 0 (9003 jobs, linting passed) · `pytest` 50/50 exit 0 · `ledger status` **367 fresh / 0 stale / 0 missing**, exit 0 · no `sorry` outside the two Comparator-contract declarations in `Challenge.lean` and upstream BrownianMotion.

Ledger note: the rebase's semantic merge driver dropped 13 rows verified differently on each side. Seven were `main`'s CRR entries, whose files this branch never touches — restoring `main`'s rows and re-running `status` returned them **fresh**, i.e. the hashes themselves confirmed the verification applies. The six rows this branch genuinely invalidated were re-verified from scratch.
