### PR TITLE
fix(docker): copy the Palomar targets into the verify image

### DIFF
--- a/docker/Dockerfile.verify
+++ b/docker/Dockerfile.verify
@@ -29,7 +29,12 @@ WORKDIR /app
 # the MathFin library + its direct deps (BrownianMotion etc.). This bakes
 # the olean tree into the image at /app/.lake/, so the first verify call no
 # longer pays for a cold Lake build.
-COPY lakefile.lean lean-toolchain lake-manifest.json MathFin.lean ./
+# `Challenge.lean` / `Solution.lean` are the Palomar registry targets that
+# `lakefile.lean` declares as `lean_lib`s. The bare `lake build` below builds
+# every declared target, so omitting them fails the image build outright --
+# publish-verify-image has been red since 2dedd2e for exactly this reason.
+COPY lakefile.lean lean-toolchain lake-manifest.json MathFin.lean \
+     Challenge.lean Solution.lean ./
 COPY MathFin/ MathFin/
 RUN elan toolchain install "$(cat lean-toolchain)" \
     && lean --version \


### PR DESCRIPTION
`publish-verify-image` has been red on every commit since **2dedd2e**, the Palomar registration. The last green publish was `c419f0f`.

`lakefile.lean` declares `lean_lib Challenge` and `lean_lib Solution`, and the image's build step runs a bare `lake build`, which builds every declared target. But `Dockerfile.verify` never copies those two files into the build context:

```
COPY lakefile.lean lean-toolchain lake-manifest.json MathFin.lean ./
COPY MathFin/ MathFin/
```

so the baked build dies with

```
buildx failed with: ERROR: failed to build: ... process
"/bin/sh -c elan toolchain install ... && lake exe cache get && lake build"
did not complete successfully: exit code: 1
```

This is the same root cause as the compose-mount fix in #206, on a second surface: the lakefile travels into the build context, the files it names do not. #206 fixed the bind mounts, which unbroke local containerised builds; this fixes the image build.

**Why it wasn't caught locally:** building this image locally is forbidden on the maintainer's host (the Mathlib layer escapes compose's memory caps), so `publish-verify-image` is the only place it runs. CI is necessarily the test for this change.

**Consequence while red:** the published `:latest` has been stale since 2026-08-17. Anything relying on the image's baked oleans — in particular the volume-repopulation shortcut documented in `docs/patterns.md`, which repopulates `/app/.lake` from the image after a rebase — has been silently falling back to a full local rebuild rather than a file copy.
