### PR TITLE
docs(readme): refresh the headline count and record the contract layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 > what is proved and what is assumed, and the deep connections between the field's pillars made
 > *load-bearing* rather than decorative.
 
-**`353` theorems · `340` delivery-ready · `0` sorries · axioms-clean · `lake build` is the proof.**
+**`367` theorems · `354` delivery-ready · `0` sorries · axioms-clean · `lake build` is the proof.**
 
 ---
 
@@ -197,6 +197,11 @@ A breadth-and-depth library across eleven areas. Headlines per area (full per-th
 - **Market microstructure** — the Avellaneda–Stoikov market-making problem: the Riccati value function,
   its approximate-HJB solution, and the constant half-spread / linear-skew closed forms, single-asset
   and multi-asset (matrix Riccati by spectral reduction).
+- **Contract reification** — a payoff language (`Payoff`/`Contract` over a typed underlying index)
+  separating *what an instrument pays* from *the model that prices it*, with evaluation proved
+  measurable, and the reified European call, put, cash-or-nothing digital and capped call reduced to
+  the closed forms the library already proves — the capped call by **composing** two European call
+  values, no third integral. Framing after Bilokon 2026 ([`docs/sources.md`](docs/sources.md)).
 - **Actuarial & DeFi** — Gompertz mortality, survival models, annuities, net premium, compound-Poisson
   MGF; constant-product (Uniswap-v2) AMMs.
 
@@ -231,6 +236,14 @@ Honesty is the point, so the gaps are explicit:
   Naming it is Clark–Ocone ([#182](https://github.com/formal-applied-math/formal-mathfin/issues/182)) and
   is open. The Itô *formula's* integrand is named throughout — that is how `dŜ = σŜ dB` is stated —
   but that is the weaker of the two facts.
+- **The contract layer is a payoff kernel, not a legal instrument.** `MathFin/Contracts/` reifies
+  what an instrument *pays* over a finite observation grid, single-asset. Calendars, business-day
+  conventions, market disruption, corporate actions and issuer credit are absent from the language and
+  are not claimed; nor is a lifecycle layer (branching contracts, outstanding notional, termination),
+  which waits on the first callable instrument to force it. One theorem in that tower —
+  `Payoff.measurable_eval_of_obsTimes_le`, the filtration-indexed *adapted* variant — still has no
+  consumer, because nothing yet integrates a contract against a filtration; its a.e.-measurable
+  sibling is consumed.
 - **Known upstream/limit gaps** — e.g. the superhedging strong-duality *equality* needs a
   finite-dimensional Farkas / polyhedral-cone closedness absent from Mathlib at this pin
   ([#39](https://github.com/formal-applied-math/formal-mathfin/issues/39)).
@@ -254,6 +267,7 @@ asserting it is still open.
 | [`docs/hjm-program.md`](docs/hjm-program.md) | The HJM formalization program: stochastic Fubini as a shared primitive, the drift condition as its consumer. |
 | [`docs/values-review.md`](docs/values-review.md) | The judgment layer: the eight review lenses and the upgrade log. |
 | [`docs/onboarding.md`](docs/onboarding.md) · [`docs/troubleshooting.md`](docs/troubleshooting.md) | Getting in, and getting unstuck. |
+| [`docs/sources.md`](docs/sources.md) | External formalisations and papers this library has learned from: what was taken from each, what was not, and where the credit lives in the code. |
 | [`docs/bridges.md`](docs/bridges.md) · [`docs/leaps.md`](docs/leaps.md) · [`docs/patterns.md`](docs/patterns.md) | The Foundations→pricing bridges, the deductive leaps, and distilled Lean proof patterns. |
 
 ## Contributing · citation · license


### PR DESCRIPTION
The README's headline banner said `353` theorems / `340` delivery-ready while the status table further down already said `367` / `354`. Same page, two different numbers.

Fixing that surfaced three genuine gaps, all about work that landed after the last README pass:

**`MathFin/Contracts/` was absent from "What's covered."** Five modules and nine corpus entries — a payoff language separating what an instrument pays from the model that prices it — with no entry in the area list.

**The honesty section did not state that layer's ceiling.** "Scope: what's not done" now records it: payoff kernels over a finite observation grid, single-asset; no calendars, business-day conventions, disruption, corporate actions or issuer credit; no lifecycle layer; and `Payoff.measurable_eval_of_obsTimes_le` still without a consumer, because nothing yet integrates a contract against a filtration. That section is where a reader goes to find out what *isn't* true, so an omission there costs more than one in the feature list.

**`docs/sources.md` was missing from the documentation table** — the catalogue of external formalisations this library has learned from, and where the credit for each lives in the code.

## Deliberately unchanged

"A breadth-and-depth library across **eleven** areas" tracks the eleven benchmark domain files, not the bullet count. The contract entries live in `mathematical_finance.json`, so adding them adds no domain and the number stands.

## Verification

Each new claim checked against the source rather than written from memory: the adapted variant is genuinely unconsumed (`grep` over `CappedCall.lean` and `Pricing.lean`), its a.e.-measurable sibling genuinely is consumed, and the four reduced instruments are the four `value_*` theorems that exist. `pytest` 50/50, exit 0.
