### PR TITLE
Glosten–Milgrom: adverse selection sets the spread, and `π > 0` is not enough

### DIFF
--- a/MathFin.lean
+++ b/MathFin.lean
@@ -25,6 +25,8 @@
   * `RiskMeasures/`  — VaR/CVaR + coherent-risk axioms, Rockafellar-Uryasev,
                        spectral risk, Herfindahl concentration.
   * `Actuarial/`     — net premium, Gompertz force of mortality.
+  * `Execution/`     — Market microstructure and execution: Glosten-Milgrom
+                       adverse-selection spread.
   * `DeFi/`          — Decentralized-finance market microstructure:
                        constant-product AMMs (Uniswap v2-style), swap
                        output, invariant preservation, internal price.
@@ -480,3 +482,8 @@ import MathFin.Contracts.Adapted
 import MathFin.Contracts.Pricing
 import MathFin.Contracts.BlackScholes
 import MathFin.Contracts.CappedCall
+
+-- Execution: market microstructure — the Glosten-Milgrom adverse-selection
+-- spread, plus a six-point model witnessing that its hypotheses are satisfiable
+import MathFin.Execution.GlostenMilgrom
+import MathFin.Execution.GlostenMilgromModel

--- a/MathFin/AxiomAudit.lean
+++ b/MathFin/AxiomAudit.lean
@@ -1257,4 +1257,54 @@ only a.e. adaptedness). -/
 #guard_msgs (whitespace := lax) in
 #print axioms MathFin.BracketCompensator.condExp_sq_sub_bracket
 
+/-! ### Glosten-Milgrom adverse selection (2026-09-01)
+
+`MathFin/Execution/GlostenMilgrom.lean` derives the bid-ask spread from adverse selection
+alone. Five theorems are pinned, one per load-bearing claim.
+
+The **trade probabilities** are derived from the trader mix rather than assumed, which is what
+separates a `full` entry from a restatement. They are stated additively
+(`2 * μ[B | H] = 1 + p`) so that no step forms a difference in a type where subtraction
+truncates — the subtracting form follows from the additive one, so this buys the proofs, not
+the statements.
+
+`cond_toReal_eq` is the **seam**: Bayes pushed through `.toReal` once, generically, which is
+what identifies the model's posterior `μ[H | B]` with the real function `postBuy` the closed
+form is about. Without it the measure-theoretic half and the real-analysis half are true
+statements about unrelated objects. `toReal` sends `∞ ↦ 0` and `x/0 ↦ 0`, so this is exactly
+where a careless bridge would manufacture a silent wrong answer.
+
+`spread_pos_of_model` is the result itself, from the model's own primitives.
+
+`spread_junk_at_corner` is why the statement carries `0 < θ < 1`, which the issue's acceptance
+criterion omits: at `θ = 1, p = 1` the closed form returns the *entire* `V_H - V_L` as the
+spread — the largest there could be — at the one point where the value is common knowledge and
+the true spread is `0`. Nothing errors; `0/0 = 0` does it. Pinning it keeps that fact from
+quietly changing under the entry that depends on it.
+
+`spread_pos_witness` closes the vacuity question: a six-point space — value high or low, trader
+informed or not, uninformed trader tossing a coin — satisfies every hypothesis of
+`spread_pos_of_model`, symbolically in `θ` and `p`, so the result is not true for want of a
+model. -/
+
+/-- info: 'MathFin.Execution.two_mul_cond_buy_high' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms MathFin.Execution.two_mul_cond_buy_high
+
+/-- info: 'MathFin.Execution.cond_toReal_eq' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms MathFin.Execution.cond_toReal_eq
+
+/-- info: 'MathFin.Execution.spread_pos_of_model' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms MathFin.Execution.spread_pos_of_model
+
+/-- info: 'MathFin.Execution.spread_junk_at_corner' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms MathFin.Execution.spread_junk_at_corner
+
+/-- info: 'MathFin.Execution.spread_pos_witness' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms MathFin.Execution.spread_pos_witness
+
 end MathFin.AxiomAudit

--- a/MathFin/AxiomAuditGen.lean
+++ b/MathFin/AxiomAuditGen.lean
@@ -8,7 +8,7 @@
 
   The curated, storied audit is MathFin/AxiomAudit.lean (headliners + dated
   narrative); THIS file is its machine-written closure over the benchmark
-  corpus (329 constants). Scope: proof-position MathFin names only —
+  corpus (330 constants). Scope: proof-position MathFin names only —
   statement-position defs are exercised by elaboration + the verification
   ledger, and library_wrapper entries cite upstream names.
 
@@ -73,6 +73,9 @@ namespace MathFin.AxiomAuditGen
 
 /-- info: 'MathFin.ErlangSum.sum_iidExp_law_gammaMeasure' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.ErlangSum.sum_iidExp_law_gammaMeasure
+
+/-- info: 'MathFin.Execution.spread_pos_of_model' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in #print axioms MathFin.Execution.spread_pos_of_model
 
 /-- info: 'MathFin.FeynmanKacHeatEquation.feynmanKac_boundary' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs (whitespace := lax) in #print axioms MathFin.FeynmanKacHeatEquation.feynmanKac_boundary

--- a/MathFin/Execution/GlostenMilgrom.lean
+++ b/MathFin/Execution/GlostenMilgrom.lean
@@ -1,0 +1,474 @@
+/-
+Copyright (c) 2026 Alfredo Garcia. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alfredo Garcia
+-/
+module
+
+public import Mathlib
+
+/-!
+# Glosten-Milgrom adverse-selection bid-ask spread
+
+Glosten and Milgrom (1985) derive the bid-ask spread from adverse selection
+alone. A fraction `p` of arriving traders know a binary asset value
+`V ∈ {V_L, V_H}`; the rest trade at random. A competitive market maker quotes
+
+  `ask = E[V | buy]`,   `bid = E[V | sell]`,
+
+updating by Bayes on the direction of the order. The spread is what is left.
+
+Two modelling conventions, both visible in the statements. The sell event is
+`Bᶜ`: every arriving trader either buys or sells, so there is no no-trade
+outcome, and `bid = E[V | Bᶜ]`. And the quotes are *posited* to be those
+conditional expectations — Glosten-Milgrom's derivation of them from a
+competitive market maker's zero expected profit is not formalized here.
+
+The four stages below are marked by section headers. The fourth is what makes
+the other three a single theorem rather than three separate ones:
+`cond_toReal_eq` is Bayes pushed through `.toReal`, and that is what identifies
+the model's posterior `μ[H | B]` with the real function `postBuy` stage 3
+reasons about. `toReal` sends `∞ ↦ 0` and `x/0 ↦ 0`, so every conversion below
+carries its `≠ ∞` side condition.
+
+The `ℝ≥0∞` stages state the trade probabilities *additively* — `2·P = 1 + p`,
+`2·P + p = 1` — so that no step ever forms a difference in a type where
+subtraction truncates. The textbook form does follow from the additive one
+(`ENNReal.eq_sub_of_add_eq`, given `p ≠ ∞`); it is the *proofs*, not the
+statements, that the additive form buys.
+
+## The hypothesis `0 < θ < 1`
+
+The usual statement of the result omits it. It is not a technical convenience,
+and the two endpoints fail for different reasons.
+
+With `p < 1` a degenerate prior leaves nothing to be adversely selected: both
+posteriors coincide, the spread is exactly `0`, and `ask - bid > 0` is false.
+
+With `p = 1` it is worse, and in two ways that are both machine-checked here.
+One of the two trade events becomes null, and `quote_eq_zero_of_null` shows what
+`cond` then returns: not a bad price but the zero measure, whose integral is `0`.
+And `spread_junk_at_corner` evaluates the closed form at `θ = 1, p = 1` — it
+returns the *entire* `V_H - V_L`, the largest spread there could be, at the one
+point where the true spread is `0`, because `0/0 = 0`. Nothing errors in either
+case. Excluding the endpoints excludes both at once.
+
+The derivation demands the hypothesis independently: `two_mul_cond_buy_high`
+needs `μ H ≠ 0` and `two_mul_cond_buy_low_add` needs `μ Hᶜ ≠ 0`, so their
+hypotheses cannot be jointly satisfied without `0 < θ < 1`.
+
+A model satisfying all of them — so the theorem is not vacuous — is in
+`MathFin.Execution.GlostenMilgromModel`.
+
+## Results
+
+* `two_mul_cond_buy_high`, `two_mul_cond_buy_low_add`: the trade probabilities,
+  derived from the trader mix.
+* `payoff`, `spread_eq`: the quotes as integrals, and the payoff cancelling.
+* `postBuy`, `postSell`, `post_sub_post`: the posteriors and the closed form
+  `4pθ(1-θ) / (1 - p²(2θ-1)²)`.
+* `cond_toReal_eq`: Bayes in `ℝ` — the seam.
+* `postBuy_eq`, `postSell_eq`: the model's posteriors *are* `postBuy`/`postSell`.
+* `spread_pos_of_model`: `∫ V ∂μ[|buy] > ∫ V ∂μ[|sell]`, from the model's own
+  primitives.
+* `quote_eq_zero_of_null`, `spread_junk_at_corner`: what the excluded endpoints
+  actually do — a quote that is not a quote, and a closed form returning the
+  whole value range.
+
+## References
+
+* L. R. Glosten and P. R. Milgrom, *Bid, ask and transaction prices in a
+  specialist market with heterogeneously informed traders*, Journal of
+  Financial Economics 14 (1985) 71-100.
+-/
+
+@[expose] public section
+
+namespace MathFin.Execution
+
+open MeasureTheory ProbabilityTheory
+open scoped ENNReal
+
+variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
+
+/-! ## Stage 1 — the trade probabilities, derived from the trader mix -/
+
+omit [MeasurableSpace Ω] [IsProbabilityMeasure μ] in
+/-- **The informed half.** On the high-value event, every informed trader buys,
+so the buy-and-informed mass is exactly the informed mass. -/
+theorem inter_informed (H B I : Set Ω) (hbuy : B ∩ I = H ∩ I) :
+    H ∩ B ∩ I = H ∩ I := by
+  rw [Set.inter_assoc, hbuy, ← Set.inter_assoc, Set.inter_self]
+
+omit [MeasurableSpace Ω] [IsProbabilityMeasure μ] in
+/-- **The informed half, low value.** An informed trader facing a low value sells,
+so the buy-and-informed mass on `Hᶜ` is empty. Derived from the same primitive —
+no extra hypothesis. -/
+theorem inter_informed_low (H B I : Set Ω) (hbuy : B ∩ I = H ∩ I) :
+    Hᶜ ∩ B ∩ I = ∅ := by
+  rw [Set.inter_assoc, hbuy, ← Set.inter_assoc, Set.compl_inter_self, Set.empty_inter]
+
+omit [IsProbabilityMeasure μ] in
+/-- **The trade probability, derived.** Doubling clears the uninformed `1/2`
+without ever subtracting: `2·μ(H ∩ B) = (1 + p)·θ`. -/
+theorem two_mul_inter_high_buy (H B I : Set Ω) (hI : MeasurableSet I) (θ p : ℝ≥0∞)
+    (hbuy : B ∩ I = H ∩ I)
+    (hindep : μ (H ∩ I) = p * θ)
+    (hH : μ H = θ)
+    (huninf : 2 * μ ((H ∩ B) \ I) = μ (H \ I)) :
+    2 * μ (H ∩ B) = (1 + p) * θ := by
+  have hsplitB : μ (H ∩ B ∩ I) + μ ((H ∩ B) \ I) = μ (H ∩ B) :=
+    measure_inter_add_sdiff (H ∩ B) hI
+  have hsplitH : μ (H ∩ I) + μ (H \ I) = μ H := measure_inter_add_sdiff H hI
+  calc 2 * μ (H ∩ B)
+      = 2 * μ (H ∩ B ∩ I) + 2 * μ ((H ∩ B) \ I) := by rw [← hsplitB, mul_add]
+    _ = 2 * μ (H ∩ I) + μ (H \ I) := by rw [inter_informed H B I hbuy, huninf]
+    _ = μ (H ∩ I) + (μ (H ∩ I) + μ (H \ I)) := by rw [two_mul, add_assoc]
+    _ = p * θ + θ := by rw [hsplitH, hindep, hH]
+    _ = (1 + p) * θ := by rw [add_mul, one_mul, add_comm]
+
+omit [IsProbabilityMeasure μ] in
+/-- **`P(buy | V_H)`, subtraction- and division-free.** The additive form
+`2·P = 1 + p` is the one `ℝ≥0∞` actually likes. -/
+theorem two_mul_cond_buy_high (H B I : Set Ω) (hH' : MeasurableSet H) (hI : MeasurableSet I)
+    (θ p : ℝ≥0∞) (hθ0 : θ ≠ 0) (hθtop : θ ≠ ∞)
+    (hbuy : B ∩ I = H ∩ I) (hindep : μ (H ∩ I) = p * θ) (hH : μ H = θ)
+    (huninf : 2 * μ ((H ∩ B) \ I) = μ (H \ I)) :
+    2 * μ[B | H] = 1 + p := by
+  have h2 : 2 * μ (H ∩ B) = (1 + p) * θ :=
+    two_mul_inter_high_buy μ H B I hI θ p hbuy hindep hH huninf
+  calc 2 * μ[B | H]
+      = 2 * (θ⁻¹ * μ (H ∩ B)) := by rw [cond_apply hH', hH]
+    _ = θ⁻¹ * (2 * μ (H ∩ B)) := by rw [mul_left_comm]
+    _ = θ⁻¹ * ((1 + p) * θ) := by rw [h2]
+    _ = 1 + p := by
+        rw [mul_comm (1 + p) θ, ← mul_assoc, ENNReal.inv_mul_cancel hθ0 hθtop, one_mul]
+
+omit [IsProbabilityMeasure μ] in
+/-- **`P(buy | V_L) = (1 − p)/2`, stated additively as `2·P + p = 1`** — because
+`1 - p` truncates in `ℝ≥0∞` and this form does not.
+
+And note which hypothesis the proof demands: `μ Hᶜ ≠ 0`, i.e. `θ ≠ 1`. Together
+with `θ ≠ 0` from the high-value case, **the model itself forces `0 < θ < 1`** —
+exactly the hypothesis the issue is missing. It is not an extra condition imposed
+on the theorem; it is what the derivation needs in order to exist. -/
+theorem two_mul_cond_buy_low_add (H B I : Set Ω) (hHc : MeasurableSet Hᶜ)
+    (hI : MeasurableSet I) (θ' p : ℝ≥0∞) (hθ0 : θ' ≠ 0) (hθtop : θ' ≠ ∞)
+    (hbuy : B ∩ I = H ∩ I)
+    (hindep : μ (Hᶜ ∩ I) = p * θ')
+    (hHc' : μ Hᶜ = θ')
+    (huninf : 2 * μ ((Hᶜ ∩ B) \ I) = μ (Hᶜ \ I)) :
+    2 * μ[B | Hᶜ] + p = 1 := by
+  have hz : μ (Hᶜ ∩ B ∩ I) = 0 := by
+    rw [inter_informed_low H B I hbuy]; exact measure_empty
+  have hsplitB : μ (Hᶜ ∩ B ∩ I) + μ ((Hᶜ ∩ B) \ I) = μ (Hᶜ ∩ B) :=
+    measure_inter_add_sdiff (Hᶜ ∩ B) hI
+  have hBmass : 2 * μ (Hᶜ ∩ B) = μ (Hᶜ \ I) := by
+    rw [← hsplitB, hz, zero_add]; exact huninf
+  have hsplitH : μ (Hᶜ ∩ I) + μ (Hᶜ \ I) = μ Hᶜ := measure_inter_add_sdiff Hᶜ hI
+  have hp : p = θ'⁻¹ * (p * θ') := by
+    rw [mul_comm p θ', ← mul_assoc, ENNReal.inv_mul_cancel hθ0 hθtop, one_mul]
+  calc 2 * μ[B | Hᶜ] + p
+      = 2 * (θ'⁻¹ * μ (Hᶜ ∩ B)) + p := by rw [cond_apply hHc, hHc']
+    _ = θ'⁻¹ * (2 * μ (Hᶜ ∩ B)) + p := by rw [mul_left_comm]
+    _ = θ'⁻¹ * μ (Hᶜ \ I) + θ'⁻¹ * μ (Hᶜ ∩ I) := by rw [hBmass, hindep, ← hp]
+    _ = θ'⁻¹ * (μ (Hᶜ ∩ I) + μ (Hᶜ \ I)) := by rw [← mul_add, add_comm]
+    _ = θ'⁻¹ * θ' := by rw [hsplitH, hHc']
+    _ = 1 := ENNReal.inv_mul_cancel hθ0 hθtop
+
+
+/-! ## Stage 2 — the quotes as Bochner integrals -/
+
+/-- The two-valued asset: `V_H` on the high event `H`, `V_L` off it. Written as
+a constant plus an indicator, which is what makes it integrable for free. -/
+noncomputable def payoff (H : Set Ω) (VL VH : ℝ) : Ω → ℝ :=
+  fun ω => VL + Set.indicator H (fun _ => VH - VL) ω
+
+/-- **The expectation of a two-valued payoff.** Against any probability measure,
+`E[V] = V_L + P(H)·(V_H − V_L)`. -/
+theorem integral_payoff (ν : Measure Ω) [IsProbabilityMeasure ν] (H : Set Ω)
+    (hH : MeasurableSet H) (VL VH : ℝ) :
+    ∫ ω, payoff H VL VH ω ∂ν = VL + (ν H).toReal * (VH - VL) := by
+  unfold payoff
+  rw [integral_add (integrable_const VL) ((integrable_const (VH - VL)).indicator hH),
+    integral_const, integral_indicator_const _ hH]
+  simp [measureReal_def]
+
+omit [IsProbabilityMeasure μ] in
+/-- **The quote.** `E[V | E]` for a conditioning event of positive probability —
+this is `ask` when `E` is a buy and `bid` when `E` is a sell. -/
+theorem integral_payoff_cond [IsFiniteMeasure μ] (E H : Set Ω) (hH : MeasurableSet H)
+    (hE0 : μ E ≠ 0) (VL VH : ℝ) :
+    ∫ ω, payoff H VL VH ω ∂(μ[|E]) = VL + (μ[H | E]).toReal * (VH - VL) := by
+  haveI : IsProbabilityMeasure (μ[|E]) := cond_isProbabilityMeasure hE0
+  exact integral_payoff (μ[|E]) H hH VL VH
+
+omit [IsProbabilityMeasure μ] in
+/-- **The spread, reduced to the posteriors.** Every trace of the payoff cancels
+except the scale `V_H − V_L`; what is left is exactly how much a buy moves the
+belief relative to a sell. Adverse selection, and nothing else, sets the spread. -/
+theorem spread_eq [IsFiniteMeasure μ] (B S H : Set Ω) (hH : MeasurableSet H)
+    (hB0 : μ B ≠ 0) (hS0 : μ S ≠ 0) (VL VH : ℝ) :
+    (∫ ω, payoff H VL VH ω ∂(μ[|B])) - (∫ ω, payoff H VL VH ω ∂(μ[|S]))
+      = (VH - VL) * ((μ[H | B]).toReal - (μ[H | S]).toReal) := by
+  rw [integral_payoff_cond μ B H hH hB0 VL VH, integral_payoff_cond μ S H hH hS0 VL VH]
+  ring
+
+omit [IsProbabilityMeasure μ] in
+/-- **A null trade event does not give a bad quote — it gives no quote.**
+`cond` on a null set is the *zero measure*, so the "price" integrates to `0`
+whatever the asset is worth. This is why `p = 1` has to be excluded along with
+the degenerate priors: at that corner one of the two trade events is null, and
+the inequality can hold for a reason unrelated to adverse selection. -/
+theorem quote_eq_zero_of_null (H B : Set Ω) (VL VH : ℝ) (hB : μ B = 0) :
+    ∫ ω, payoff H VL VH ω ∂(μ[|B]) = 0 := by
+  rw [cond_eq_zero_of_meas_eq_zero hB]; simp
+
+/-! ## Stage 3 — the closed form and strict positivity, in `ℝ` -/
+
+/-- Posterior that the value is high, after a buy: `θ(1+p) / (1 + p(2θ−1))`. -/
+noncomputable def postBuy (θ p : ℝ) : ℝ := (1 + p) * θ / (1 + p * (2 * θ - 1))
+
+/-- Posterior that the value is high, after a sell: `θ(1−p) / (1 − p(2θ−1))`. -/
+noncomputable def postSell (θ p : ℝ) : ℝ := (1 - p) * θ / (1 - p * (2 * θ - 1))
+
+/-- The buy denominator is positive. Note `1 + p(2θ−1)` is *twice* `P(buy)`
+(see `hBreal` in `spread_pos_of_model`), not `P(buy)` itself. Positivity holds
+because it equals `(1−p) + 2pθ`, two non-negative terms with the second strictly
+positive — which is the hint `nlinarith` is given, so no case split on the sign
+of `2θ−1` is needed. -/
+theorem buy_denom_pos {θ p : ℝ} (hθ0 : 0 < θ) (hp0 : 0 < p) (hp1 : p ≤ 1) :
+    0 < 1 + p * (2 * θ - 1) := by nlinarith [mul_pos hp0 hθ0]
+
+/-- The sell denominator is positive — likewise *twice* `P(sell)` — by the mirror
+identity `1 − p(2θ−1) = (1−p) + 2p(1−θ)`. -/
+theorem sell_denom_pos {θ p : ℝ} (hθ1 : θ < 1) (hp0 : 0 < p) (hp1 : p ≤ 1) :
+    0 < 1 - p * (2 * θ - 1) := by nlinarith [mul_pos hp0 (sub_pos.mpr hθ1)]
+
+/-- **The closed form of the spread's belief term** — the formula the issue's
+`## Task` states, now derived:
+`postBuy − postSell = 4pθ(1−θ) / (1 − p²(2θ−1)²)`.
+
+The `θ(1−θ)` in the numerator is the whole point: it is what the acceptance
+criterion forgets, and it vanishes exactly at `θ ∈ {0,1}`. -/
+theorem post_sub_post {θ p : ℝ} (hθ0 : 0 < θ) (hθ1 : θ < 1) (hp0 : 0 < p)
+    (hp1 : p ≤ 1) :
+    postBuy θ p - postSell θ p
+      = 4 * p * θ * (1 - θ) / (1 - p ^ 2 * (2 * θ - 1) ^ 2) := by
+  have h1 := (buy_denom_pos hθ0 hp0 hp1).ne'
+  have h2 := (sell_denom_pos hθ1 hp0 hp1).ne'
+  have h3 : (1 : ℝ) - p ^ 2 * (2 * θ - 1) ^ 2
+      = (1 + p * (2 * θ - 1)) * (1 - p * (2 * θ - 1)) := by ring
+  have hD : (1 : ℝ) - p ^ 2 * (2 * θ - 1) ^ 2 ≠ 0 := by rw [h3]; exact mul_ne_zero h1 h2
+  unfold postBuy postSell
+  rw [div_sub_div _ _ h1 h2, div_eq_div_iff (mul_ne_zero h1 h2) hD]
+  ring
+
+/-- **A buy moves the belief strictly more than a sell does.** This is the whole
+economic content: the order's direction is informative, so the two quotes cannot
+coincide. -/
+theorem postSell_lt_postBuy {θ p : ℝ} (hθ0 : 0 < θ) (hθ1 : θ < 1) (hp0 : 0 < p)
+    (hp1 : p ≤ 1) : postSell θ p < postBuy θ p := by
+  have h1 := buy_denom_pos hθ0 hp0 hp1
+  have h2 := sell_denom_pos hθ1 hp0 hp1
+  have hdiff : 0 < postBuy θ p - postSell θ p := by
+    rw [post_sub_post hθ0 hθ1 hp0 hp1]
+    apply div_pos
+    · nlinarith [mul_pos (mul_pos hp0 hθ0) (sub_pos.mpr hθ1)]
+    · nlinarith
+  linarith
+
+/-- **The theorem the issue asks for**, with the hypotheses it is missing:
+`ask − bid > 0` whenever `V_L < V_H`, `0 < p ≤ 1` **and `0 < θ < 1`** — where
+`ask − bid = (V_H − V_L)·(postBuy − postSell)` is exactly Stage 2's `spread_eq`. -/
+theorem spread_pos {θ p VL VH : ℝ} (hθ0 : 0 < θ) (hθ1 : θ < 1) (hp0 : 0 < p)
+    (hp1 : p ≤ 1) (hV : VL < VH) :
+    0 < (VH - VL) * (postBuy θ p - postSell θ p) :=
+  mul_pos (sub_pos.mpr hV) (sub_pos.mpr (postSell_lt_postBuy hθ0 hθ1 hp0 hp1))
+
+/-- `postSell 1 1 = 0/0`, which Lean evaluates to `0` rather than rejecting. -/
+theorem postSell_one_one : postSell 1 1 = 0 := by unfold postSell; norm_num
+
+/-- **The punchline.** At `θ = 1, p = 1` the closed form hands back the *entire
+value range* as the spread — the largest it could conceivably be — at exactly the
+point where the value is common knowledge and the true spread is `0`. Nothing
+errors, nothing is flagged; `0/0 = 0` does it all. A `full` entry quantified over
+`p ≤ 1` and unconstrained `θ` would carry this inside it. -/
+theorem spread_junk_at_corner (VL VH : ℝ) :
+    (VH - VL) * (postBuy 1 1 - postSell 1 1) = VH - VL := by
+  unfold postBuy postSell; norm_num
+
+/-! ## Stage 4 — the seam -/
+
+/-- **The unconditional probability of `E`, in `ℝ`.** The law of total
+probability, converted once. -/
+theorem measure_toReal_of_likelihoods (E H : Set Ω) (hH : MeasurableSet H)
+    {a c t : ℝ} (ha : (μ[E | H]).toReal = a) (hc : (μ[E | Hᶜ]).toReal = c)
+    (ht : (μ H).toReal = t) :
+    (μ E).toReal = a * t + c * (1 - t) := by
+  have hcompl : (μ Hᶜ).toReal = 1 - t := by
+    rw [← measureReal_def, probReal_compl_eq_one_sub hH, measureReal_def, ht]
+  have h := congrArg ENNReal.toReal (cond_add_cond_compl_eq (μ := μ) (t := E) hH)
+  rw [ENNReal.toReal_add
+      (ENNReal.mul_ne_top (measure_ne_top _ E) (measure_ne_top _ _))
+      (ENNReal.mul_ne_top (measure_ne_top _ E) (measure_ne_top _ _)),
+    ENNReal.toReal_mul, ENNReal.toReal_mul, ha, hc, ht, hcompl] at h
+  exact h.symm
+
+/-- **THE SEAM.** Bayes' theorem, pushed through `.toReal`: the posterior on `H`
+after observing `E` is the Bayes ratio of the two likelihoods against the prior.
+
+This is what makes the stages one argument rather than three. Stage 2 hands back
+`(μ[H | E]).toReal`; Stage 3 reasons about a ratio of real numbers; this says they
+are the same number. No hypothesis that the denominator is nonzero is needed —
+in the degenerate case both sides are `0`, which is precisely the behaviour the
+issue's statement must not be allowed to hide. -/
+theorem cond_toReal_eq (E H : Set Ω) (hE : MeasurableSet E) (hH : MeasurableSet H)
+    {a c t : ℝ} (ha : (μ[E | H]).toReal = a) (hc : (μ[E | Hᶜ]).toReal = c)
+    (ht : (μ H).toReal = t) :
+    (μ[H | E]).toReal = a * t / (a * t + c * (1 - t)) := by
+  rw [cond_eq_inv_mul_cond_mul hE hH μ, ENNReal.toReal_mul, ENNReal.toReal_mul,
+    ENNReal.toReal_inv, measure_toReal_of_likelihoods μ E H hH ha hc ht, ha, ht,
+    div_eq_inv_mul]
+  ring
+
+omit [IsProbabilityMeasure μ] in
+/-- **The complementary likelihood.** `P(Eᶜ | F) = 1 − P(E | F)`, in `ℝ`, given
+that `F` is not null — the hypothesis the model already forces. -/
+theorem cond_compl_toReal [IsFiniteMeasure μ] (E F : Set Ω) (hE : MeasurableSet E)
+    (hF0 : μ F ≠ 0) :
+    (μ[Eᶜ | F]).toReal = 1 - (μ[E | F]).toReal := by
+  haveI : IsProbabilityMeasure (μ[|F]) := cond_isProbabilityMeasure hF0
+  rw [← measureReal_def, probReal_compl_eq_one_sub hE, measureReal_def]
+
+omit [IsProbabilityMeasure μ] in
+/-- `P(buy | V_H) = (1+p)/2`, converted from Stage 1's additive form. -/
+theorem cond_buy_high_toReal (H B : Set Ω) {p : ℝ} (hp0 : 0 ≤ p)
+    (hhigh : 2 * μ[B | H] = 1 + ENNReal.ofReal p) :
+    (μ[B | H]).toReal = (1 + p) / 2 := by
+  have h := congrArg ENNReal.toReal hhigh
+  rw [ENNReal.toReal_mul, ENNReal.toReal_add ENNReal.one_ne_top ENNReal.ofReal_ne_top,
+    ENNReal.toReal_ofReal hp0] at h
+  simp only [ENNReal.toReal_ofNat, ENNReal.toReal_one] at h
+  linarith
+
+omit [IsProbabilityMeasure μ] in
+/-- `P(buy | V_L) = (1−p)/2`, converted from Stage 1's additive form. -/
+theorem cond_buy_low_toReal (H B : Set Ω) {p : ℝ} (hp0 : 0 ≤ p)
+    (hlow : 2 * μ[B | Hᶜ] + ENNReal.ofReal p = 1) :
+    (μ[B | Hᶜ]).toReal = (1 - p) / 2 := by
+  have h := congrArg ENNReal.toReal hlow
+  rw [ENNReal.toReal_add
+      (ENNReal.mul_ne_top (by simp) (measure_ne_top _ B)) ENNReal.ofReal_ne_top,
+    ENNReal.toReal_mul, ENNReal.toReal_ofReal hp0] at h
+  simp only [ENNReal.toReal_ofNat, ENNReal.toReal_one] at h
+  linarith
+
+/-- **The posterior after a buy is exactly `postBuy`.** Stage 3's `postBuy` was a
+real function of two real numbers with no measure in sight; this is the theorem
+that makes it the model's posterior. -/
+theorem postBuy_eq (H B : Set Ω) (hB : MeasurableSet B) (hH : MeasurableSet H)
+    {θ p : ℝ} (hp0 : 0 ≤ p) (ht : (μ H).toReal = θ)
+    (hhigh : 2 * μ[B | H] = 1 + ENNReal.ofReal p)
+    (hlow : 2 * μ[B | Hᶜ] + ENNReal.ofReal p = 1) :
+    (μ[H | B]).toReal = postBuy θ p := by
+  rw [cond_toReal_eq μ B H hB hH (cond_buy_high_toReal μ H B hp0 hhigh)
+      (cond_buy_low_toReal μ H B hp0 hlow) ht, postBuy,
+    show (1 + p) / 2 * θ + (1 - p) / 2 * (1 - θ) = (1 + p * (2 * θ - 1)) / 2 by ring,
+    show (1 + p) / 2 * θ = (1 + p) * θ / 2 by ring]
+  exact div_div_div_cancel_right₀ two_ne_zero _ _
+
+/-- **The posterior after a sell is exactly `postSell`.** The sell event is
+`Bᶜ` — every arriving trader either buys or sells — so the likelihoods are the
+buy ones swapped, and the same seam lemma does the work.
+
+Only `μ Hᶜ ≠ 0` (that is, `θ ≠ 1`) is taken as a hypothesis. Its mirror
+`μ H ≠ 0` is *derived*: at a degenerate prior `cond` collapses to the zero
+measure, so `hhigh` would read `0 = 1 + p`. -/
+theorem postSell_eq (H B : Set Ω) (hB : MeasurableSet B) (hH : MeasurableSet H)
+    {θ p : ℝ} (hp0 : 0 ≤ p) (ht : (μ H).toReal = θ) (hHc0 : μ Hᶜ ≠ 0)
+    (hhigh : 2 * μ[B | H] = 1 + ENNReal.ofReal p)
+    (hlow : 2 * μ[B | Hᶜ] + ENNReal.ofReal p = 1) :
+    (μ[H | Bᶜ]).toReal = postSell θ p := by
+  have hH0 : μ H ≠ 0 := by
+    intro h
+    have hz : (0 : ℝ≥0∞) = 1 + ENNReal.ofReal p := by
+      rw [← hhigh, cond_eq_zero_of_meas_eq_zero h]; simp
+    exact absurd hz.symm (by simp)
+  have hsa : (μ[Bᶜ | H]).toReal = (1 - p) / 2 := by
+    rw [cond_compl_toReal μ B H hB hH0, cond_buy_high_toReal μ H B hp0 hhigh]; ring
+  have hsc : (μ[Bᶜ | Hᶜ]).toReal = (1 + p) / 2 := by
+    rw [cond_compl_toReal μ B Hᶜ hB hHc0, cond_buy_low_toReal μ H B hp0 hlow]; ring
+  rw [cond_toReal_eq μ Bᶜ H hB.compl hH hsa hsc ht, postSell,
+    show (1 - p) / 2 * θ + (1 + p) / 2 * (1 - θ) = (1 - p * (2 * θ - 1)) / 2 by ring,
+    show (1 - p) / 2 * θ = (1 - p) * θ / 2 by ring]
+  exact div_div_div_cancel_right₀ two_ne_zero _ _
+
+/-- **Glosten–Milgrom: the spread is strictly positive.** The market maker's ask
+and bid are `∫ V ∂μ[|buy]` and `∫ V ∂μ[|sell]`, and the first strictly exceeds
+the second whenever `V_L < V_H`, `0 < π ≤ 1` **and `0 < θ < 1`**.
+
+This is the issue's `## Acceptance criteria`, with the hypothesis it omits. The
+chain is: Stage 1 derives the trade probabilities from the trader mix; Stage 4
+converts them and applies Bayes to get the posteriors; Stage 2 turns the quotes
+into those posteriors; Stage 3 supplies the strict inequality. -/
+theorem spread_pos_of_model (H B I : Set Ω)
+    (hH : MeasurableSet H) (hB : MeasurableSet B) (hI : MeasurableSet I)
+    {θ p VL VH : ℝ}
+    (hθ0 : 0 < θ) (hθ1 : θ < 1) (hp0 : 0 < p) (hV : VL < VH)
+    (hprior : μ H = ENNReal.ofReal θ)
+    (hbuy : B ∩ I = H ∩ I)
+    (hindepH : μ (H ∩ I) = ENNReal.ofReal p * ENNReal.ofReal θ)
+    (hindepHc : μ (Hᶜ ∩ I) = ENNReal.ofReal p * ENNReal.ofReal (1 - θ))
+    (huninfH : 2 * μ ((H ∩ B) \ I) = μ (H \ I))
+    (huninfHc : 2 * μ ((Hᶜ ∩ B) \ I) = μ (Hᶜ \ I)) :
+    0 < (∫ ω, payoff H VL VH ω ∂(μ[|B])) - (∫ ω, payoff H VL VH ω ∂(μ[|Bᶜ])) := by
+  have hθ0' : (0:ℝ) ≤ θ := hθ0.le
+  -- `p ≤ 1` is not a hypothesis: the informed mass cannot exceed the prior.
+  have hp1 : p ≤ 1 := by
+    have h := measure_mono (μ := μ) (Set.inter_subset_left (s := H) (t := I))
+    rw [hindepH, hprior, ← ENNReal.ofReal_mul hp0.le,
+      ENNReal.ofReal_le_ofReal_iff hθ0'] at h
+    nlinarith
+  have hoθ0 : ENNReal.ofReal θ ≠ 0 := by rw [Ne, ENNReal.ofReal_eq_zero]; linarith
+  have hoθc0 : ENNReal.ofReal (1 - θ) ≠ 0 := by rw [Ne, ENNReal.ofReal_eq_zero]; linarith
+  have hpriorc : μ Hᶜ = ENNReal.ofReal (1 - θ) := by
+    rw [prob_compl_eq_one_sub hH, hprior, ENNReal.ofReal_sub 1 hθ0', ENNReal.ofReal_one]
+  have ht : (μ H).toReal = θ := by rw [hprior]; exact ENNReal.toReal_ofReal hθ0'
+  have hH0 : μ H ≠ 0 := by rw [hprior]; exact hoθ0
+  have hHc0 : μ Hᶜ ≠ 0 := by rw [hpriorc]; exact hoθc0
+  -- Stage 1: the trade probabilities, derived from the trader mix
+  have hhigh : 2 * μ[B | H] = 1 + ENNReal.ofReal p :=
+    two_mul_cond_buy_high μ H B I hH hI _ _ hoθ0
+      ENNReal.ofReal_ne_top hbuy hindepH hprior huninfH
+  have hlow : 2 * μ[B | Hᶜ] + ENNReal.ofReal p = 1 :=
+    two_mul_cond_buy_low_add μ H B I hH.compl hI _ _ hoθc0
+      ENNReal.ofReal_ne_top hbuy hindepHc hpriorc huninfHc
+  -- both trade events have positive probability, so neither conditioning is vacuous
+  have ha := cond_buy_high_toReal μ H B hp0.le hhigh
+  have hc := cond_buy_low_toReal μ H B hp0.le hlow
+  have hsa : (μ[Bᶜ | H]).toReal = (1 - p) / 2 := by
+    rw [cond_compl_toReal μ B H hB hH0, ha]; ring
+  have hsc : (μ[Bᶜ | Hᶜ]).toReal = (1 + p) / 2 := by
+    rw [cond_compl_toReal μ B Hᶜ hB hHc0, hc]; ring
+  have hBreal : (μ B).toReal = (1 + p * (2 * θ - 1)) / 2 := by
+    rw [measure_toReal_of_likelihoods μ B H hH ha hc ht]; ring
+  have hBcreal : (μ Bᶜ).toReal = (1 - p * (2 * θ - 1)) / 2 := by
+    rw [measure_toReal_of_likelihoods μ Bᶜ H hH hsa hsc ht]; ring
+  have hB0 : μ B ≠ 0 := by
+    intro h
+    rw [h] at hBreal
+    simp only [ENNReal.toReal_zero] at hBreal
+    linarith [buy_denom_pos hθ0 hp0 hp1]
+  have hBc0 : μ Bᶜ ≠ 0 := by
+    intro h
+    rw [h] at hBcreal
+    simp only [ENNReal.toReal_zero] at hBcreal
+    linarith [sell_denom_pos hθ1 hp0 hp1]
+  -- Stage 2 reduces the quotes to the posteriors; Stage 4 names them; Stage 3 closes
+  rw [spread_eq μ B Bᶜ H hH hB0 hBc0 VL VH,
+    postBuy_eq μ H B hB hH hp0.le ht hhigh hlow,
+    postSell_eq μ H B hB hH hp0.le ht hHc0 hhigh hlow]
+  exact spread_pos hθ0 hθ1 hp0 hp1 hV
+
+end MathFin.Execution

--- a/MathFin/Execution/GlostenMilgromModel.lean
+++ b/MathFin/Execution/GlostenMilgromModel.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 Alfredo Garcia. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alfredo Garcia
+-/
+module
+
+public import Mathlib
+public import MathFin.Execution.GlostenMilgrom
+
+/-!
+# A model satisfying the Glosten-Milgrom hypotheses
+
+`MathFin.Execution.spread_pos_of_model` quantifies over a probability space and
+three events tied together by four equations. If nothing satisfies those
+equations the theorem is vacuously true and says nothing — which is the same
+failure mode the module it belongs to exists to warn about, one level up.
+
+This file removes the doubt by exhibiting the model. Six outcomes: the value is
+high or low, the arriving trader is informed or not, and an uninformed trader
+tosses a coin.
+
+| `i` | value | trader     | acts | mass           |
+|-----|-------|------------|------|----------------|
+| `0` | high  | informed   | buy  | `θp`           |
+| `1` | high  | uninformed | buy  | `θ(1-p)/2`     |
+| `2` | high  | uninformed | sell | `θ(1-p)/2`     |
+| `3` | low   | informed   | sell | `(1-θ)p`       |
+| `4` | low   | uninformed | buy  | `(1-θ)(1-p)/2` |
+| `5` | low   | uninformed | sell | `(1-θ)(1-p)/2` |
+
+The witness is symbolic: it works for *every* `0 < θ < 1` and `0 < p ≤ 1`, not
+at one convenient point.
+
+## Results
+
+* `gmMeasure`, `gmHigh`, `gmBuy`, `gmInf`: the space, and the three events.
+* `gm_buy_inter_inf`: an informed trader buys exactly when the value is high —
+  on this space, a set identity.
+* `gmMeasure_univ_eq_one`: the six masses add to one.
+* `spread_pos_witness`: the spread is strictly positive, with no
+  measure-theoretic hypothesis left in front of it.
+-/
+
+@[expose] public section
+
+namespace MathFin.Execution
+
+open MeasureTheory ProbabilityTheory
+open scoped ENNReal
+
+/-- The six outcome masses. -/
+noncomputable def gmWeight (θ p : ℝ) : Fin 6 → ℝ :=
+  ![θ * p, θ * (1 - p) / 2, θ * (1 - p) / 2,
+    (1 - θ) * p, (1 - θ) * (1 - p) / 2, (1 - θ) * (1 - p) / 2]
+
+/-- The model measure: the six masses on the six outcomes. -/
+noncomputable def gmMeasure (θ p : ℝ) : Measure (Fin 6) :=
+  Measure.sum fun i => ENNReal.ofReal (gmWeight θ p i) • Measure.dirac i
+
+/-- The value is high. -/
+def gmHigh : Set (Fin 6) := {0, 1, 2}
+/-- The arriving trader buys. -/
+def gmBuy : Set (Fin 6) := {0, 1, 4}
+/-- The arriving trader is informed. -/
+def gmInf : Set (Fin 6) := {0, 3}
+
+/-- Every set's measure is the sum of the masses it contains. -/
+theorem gmMeasure_apply (θ p : ℝ) (s : Set (Fin 6)) :
+    gmMeasure θ p s
+      = ∑ i, Set.indicator s (fun j => ENNReal.ofReal (gmWeight θ p j)) i := by
+  rw [gmMeasure, Measure.sum_apply _ MeasurableSet.of_discrete, tsum_fintype]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [Measure.smul_apply, Measure.dirac_apply' i MeasurableSet.of_discrete, smul_eq_mul]
+  by_cases h : i ∈ s <;> simp [h]
+
+/-- On the parameter range that matters, every mass is nonnegative. -/
+theorem gmWeight_nonneg {θ p : ℝ} (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1) (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
+    ∀ i, 0 ≤ gmWeight θ p i := by
+  intro i; fin_cases i <;> simp [gmWeight] <;> nlinarith
+
+/-- The measure of a set, as one real number. -/
+theorem gmMeasure_eq_ofReal {θ p : ℝ} (hnn : ∀ i, 0 ≤ gmWeight θ p i) (s : Set (Fin 6)) :
+    gmMeasure θ p s = ENNReal.ofReal (∑ i, Set.indicator s (gmWeight θ p) i) := by
+  rw [gmMeasure_apply, ENNReal.ofReal_sum_of_nonneg]
+  · refine Finset.sum_congr rfl fun i _ => ?_
+    by_cases hi : i ∈ s <;> simp [hi]
+  · intro i _; by_cases hi : i ∈ s <;> simp [hi, hnn i]
+
+/-! ## The masses of the sets the model constrains -/
+
+section Values
+variable {θ p : ℝ} (hnn : ∀ i, 0 ≤ gmWeight θ p i)
+include hnn
+
+theorem gmMeasure_univ_eq_one : gmMeasure θ p Set.univ = 1 := by
+  rw [gmMeasure_eq_ofReal hnn, show (1 : ℝ≥0∞) = ENNReal.ofReal 1 by simp]
+  congr 1
+  simp [gmWeight, Fin.sum_univ_six]; ring
+
+theorem gmMeasure_high_eq : gmMeasure θ p gmHigh = ENNReal.ofReal θ := by
+  rw [gmMeasure_eq_ofReal hnn]; congr 1
+  simp [gmHigh, gmWeight, Fin.sum_univ_six]; ring
+
+theorem gmMeasure_high_compl_eq : gmMeasure θ p gmHighᶜ = ENNReal.ofReal (1 - θ) := by
+  rw [gmMeasure_eq_ofReal hnn]; congr 1
+  simp [gmHigh, gmWeight, Fin.sum_univ_six]; ring
+
+theorem gmMeasure_high_inter_inf (hp0 : 0 ≤ p) :
+    gmMeasure θ p (gmHigh ∩ gmInf) = ENNReal.ofReal p * ENNReal.ofReal θ := by
+  rw [gmMeasure_eq_ofReal hnn, ← ENNReal.ofReal_mul hp0]; congr 1
+  simp [gmHigh, gmInf, gmWeight, Fin.sum_univ_six]; ring
+
+theorem gmMeasure_low_inter_inf (hp0 : 0 ≤ p) :
+    gmMeasure θ p (gmHighᶜ ∩ gmInf) = ENNReal.ofReal p * ENNReal.ofReal (1 - θ) := by
+  rw [gmMeasure_eq_ofReal hnn, ← ENNReal.ofReal_mul hp0]; congr 1
+  simp [gmHigh, gmInf, gmWeight, Fin.sum_univ_six]; ring
+
+theorem gmMeasure_uninformed_high :
+    2 * gmMeasure θ p ((gmHigh ∩ gmBuy) \ gmInf) = gmMeasure θ p (gmHigh \ gmInf) := by
+  rw [gmMeasure_eq_ofReal hnn, gmMeasure_eq_ofReal hnn,
+    show (2 : ℝ≥0∞) = ENNReal.ofReal 2 by simp, ← ENNReal.ofReal_mul (by norm_num)]
+  congr 1
+  simp [gmHigh, gmBuy, gmInf, gmWeight, Fin.sum_univ_six]; ring
+
+theorem gmMeasure_uninformed_low :
+    2 * gmMeasure θ p ((gmHighᶜ ∩ gmBuy) \ gmInf) = gmMeasure θ p (gmHighᶜ \ gmInf) := by
+  rw [gmMeasure_eq_ofReal hnn, gmMeasure_eq_ofReal hnn,
+    show (2 : ℝ≥0∞) = ENNReal.ofReal 2 by simp, ← ENNReal.ofReal_mul (by norm_num)]
+  congr 1
+  simp [gmHigh, gmBuy, gmInf, gmWeight, Fin.sum_univ_six]; ring
+
+end Values
+
+/-- **An informed trader buys exactly when the value is high.** The one
+behavioural primitive, and on this space it is a set identity. -/
+theorem gm_buy_inter_inf : gmBuy ∩ gmInf = gmHigh ∩ gmInf := by
+  ext i; fin_cases i <;> simp [gmBuy, gmInf, gmHigh]
+
+/-- The six masses add to one. -/
+theorem gmMeasure_isProbabilityMeasure {θ p : ℝ} (hnn : ∀ i, 0 ≤ gmWeight θ p i) :
+    IsProbabilityMeasure (gmMeasure θ p) :=
+  ⟨gmMeasure_univ_eq_one hnn⟩
+
+/-- **The model exists, so the theorem is not vacuous.** Every hypothesis of
+`spread_pos_of_model` is discharged by the six-point space, for *every*
+`0 < θ < 1` and `0 < π ≤ 1` — not merely at one lucky point. What is left is the
+conclusion, with no measure-theoretic hypothesis in front of it: the ask strictly
+exceeds the bid. -/
+theorem spread_pos_witness {θ p VL VH : ℝ}
+    (hθ0 : 0 < θ) (hθ1 : θ < 1) (hp0 : 0 < p) (hp1 : p ≤ 1) (hV : VL < VH) :
+    0 < (∫ ω, payoff gmHigh VL VH ω ∂((gmMeasure θ p)[|gmBuy]))
+      - (∫ ω, payoff gmHigh VL VH ω ∂((gmMeasure θ p)[|gmBuyᶜ])) := by
+  have hnn := gmWeight_nonneg hθ0.le hθ1.le hp0.le hp1
+  haveI := gmMeasure_isProbabilityMeasure hnn
+  exact spread_pos_of_model (gmMeasure θ p) gmHigh gmBuy gmInf
+    MeasurableSet.of_discrete MeasurableSet.of_discrete MeasurableSet.of_discrete
+    hθ0 hθ1 hp0 hV (gmMeasure_high_eq hnn) gm_buy_inter_inf
+    (gmMeasure_high_inter_inf hnn hp0.le) (gmMeasure_low_inter_inf hnn hp0.le)
+    (gmMeasure_uninformed_high hnn) (gmMeasure_uninformed_low hnn)
+
+end MathFin.Execution

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 > what is proved and what is assumed, and the deep connections between the field's pillars made
 > *load-bearing* rather than decorative.
 
-**`369` theorems · `356` delivery-ready · `0` sorries · axioms-clean · `lake build` is the proof.**
+**`370` theorems · `357` delivery-ready · `0` sorries · axioms-clean · `lake build` is the proof.**
 
 ---
 
@@ -103,21 +103,21 @@ See [`MathFin/Examples.lean`](MathFin/Examples.lean) for a curated tour.
 
 | | |
 |---|---:|
-| theorems (machine-checked) | **369** |
-| delivery-ready (`full` + `library_wrapper`) | **356** |
-| full derivations | 338 |
+| theorems (machine-checked) | **370** |
+| delivery-ready (`full` + `library_wrapper`) | **357** |
+| full derivations | 339 |
 | library wrappers | 18 |
 | reduced cores (honest special cases) | 13 |
 | placeholders / sorries | **0** |
-| Lean modules · lines of Lean | 284 · ~61,900 |
-| verification ledger | 369 fresh, 0 stale |
+| Lean modules · lines of Lean | 286 · ~62,600 |
+| verification ledger | 370 fresh, 0 stale |
 | axioms used | `propext, Classical.choice, Quot.sound` only |
 | Lean / Mathlib | `v4.32.0` / `81a5d257`, pinned ([`lean-toolchain`](lean-toolchain), [`lake-manifest.json`](lake-manifest.json)) |
 
 The library is organized by theme under [`MathFin/`](MathFin): `Foundations/` (138 modules — the
 stochastic core), `BlackScholes/` (51), `FixedIncome/` (24), `Binomial/` (18), `Portfolio/` (14),
 `RiskMeasures/` (10), `Actuarial/` (6), `Contracts/` (5), `Performance/` (5), `Futures/` (3),
-`Bridges/` (2), `DeFi/` (1).
+`Bridges/` (2), `DeFi/` (1), `Execution/` (2).
 
 ## Quick start
 
@@ -196,7 +196,9 @@ A breadth-and-depth library across eleven areas. Headlines per area (full per-th
   Feynman–Kac, and **the convex-duality unification**.
 - **Market microstructure** — the Avellaneda–Stoikov market-making problem: the Riccati value function,
   its approximate-HJB solution, and the constant half-spread / linear-skew closed forms, single-asset
-  and multi-asset (matrix Riccati by spectral reduction).
+  and multi-asset (matrix Riccati by spectral reduction); and the **Glosten–Milgrom**
+  adverse-selection spread, where the quotes are Bayesian conditional expectations of the value
+  given the order's direction.
 - **Contract reification** — a payoff language (`Payoff`/`Contract` over a typed underlying index)
   separating *what an instrument pays* from *the model that prices it*, with evaluation proved
   measurable, and the reified European call, put, cash-or-nothing digital and capped call reduced to

--- a/benchmarks/mathematical_finance.json
+++ b/benchmarks/mathematical_finance.json
@@ -4096,6 +4096,22 @@
         "formalization_status": "full",
         "formalization_scope": "Full formal proof. value_cappedCall in MathFin/Contracts/CappedCall.lean: cappedCall K1 K2 T's Contract.value under the single-asset Black-Scholes model is exactly the difference of the two value_europeanCall closed forms, by Contract.value_both and Contract.value_scale applied to value_europeanCall twice and closed by ring -- Contract.value is never unfolded and no integral is touched a third time. The Integrable hypotheses Contract.value_both needs are discharged internally by integrable_europeanCall_pathPV (domination against the terminal asset price bsTerminal, itself integrable via the Gaussian MGF transfer integrable_exp_mul_of_hasLaw), so the caller supplies only the BSCallHyp bundle each leg's value_europeanCall already needs -- a real strengthening over the bare linearity lemma, which would otherwise leave two Integrable side-conditions for the caller. Payoff kernels over a finite observation grid, single-asset, observing only at T. Not a legal instrument: calendars, business-day conventions, market disruption, corporate actions and issuer credit are absent from the model and not claimed. Axioms-clean."
       }
+    },
+    {
+      "id": "mf-glosten-milgrom-spread-positive",
+      "name": "Glosten-Milgrom Adverse-Selection Spread Is Positive",
+      "description": "The market maker's ask strictly exceeds its bid, from the trader mix alone: the quotes are Bayesian conditional expectations of the asset value given the order's direction, and a buy moves the posterior strictly more than a sell. Requires 0 < theta < 1, which the usual statement of the result omits.",
+      "domain": "mathematical_finance",
+      "code": {
+        "lean": "import MathFin.Execution.GlostenMilgrom\n\nopen MathFin.Execution MeasureTheory ProbabilityTheory\n\ntheorem glostenMilgrom_spread_pos_thm {Ω : Type*} [MeasurableSpace Ω]\n    (μ : Measure Ω) [IsProbabilityMeasure μ] (H B I : Set Ω)\n    (hH : MeasurableSet H) (hB : MeasurableSet B) (hI : MeasurableSet I)\n    {θ p VL VH : ℝ}\n    (hθ0 : 0 < θ) (hθ1 : θ < 1) (hp0 : 0 < p) (hV : VL < VH)\n    (hprior : μ H = ENNReal.ofReal θ)\n    (hbuy : B ∩ I = H ∩ I)\n    (hindepH : μ (H ∩ I) = ENNReal.ofReal p * ENNReal.ofReal θ)\n    (hindepHc : μ (Hᶜ ∩ I) = ENNReal.ofReal p * ENNReal.ofReal (1 - θ))\n    (huninfH : 2 * μ ((H ∩ B) \\ I) = μ (H \\ I))\n    (huninfHc : 2 * μ ((Hᶜ ∩ B) \\ I) = μ (Hᶜ \\ I)) :\n    0 < (∫ ω, payoff H VL VH ω ∂(μ[|B])) - (∫ ω, payoff H VL VH ω ∂(μ[|Bᶜ])) :=\n  MathFin.Execution.spread_pos_of_model μ H B I hH hB hI hθ0 hθ1 hp0 hV hprior hbuy\n    hindepH hindepHc huninfH huninfHc\n"
+      },
+      "metadata": {
+        "chapter": 16,
+        "reference": "Glosten & Milgrom, Bid, ask and transaction prices in a specialist market with heterogeneously informed traders, J. Financial Economics 14 (1985) 71-100",
+        "difficulty": "advanced",
+        "formalization_status": "full",
+        "formalization_scope": "Full formal proof from the model's four primitives -- the prior, informed/value independence, informed traders trading on the value, and uninformed traders tossing a coin. Trade probabilities are derived rather than assumed; quotes are Bochner integrals against the conditioned measures; Bayes is applied through ENNReal.toReal with every finiteness side condition discharged. Axioms-clean. LIMITS: one-period and two-valued, with no dynamics -- no sequence of trades and no convergence of quotes to the true value. The competitive market maker's zero-expected-profit condition is NOT formalized: ask = E[V | buy] and bid = E[V | sell] are posited by the shape of the conclusion, not derived. The sell event is modelled as the complement of the buy event, so there is no no-trade outcome. The statement carries 0 < theta < 1, which the acceptance criterion as written omits."
+      }
     }
   ]
 }

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -26,12 +26,63 @@ Report `reduced_core` and `placeholder` separately. **Spec-with-axiomatized-conc
 
 ## Current Audit
 
-> **Live status (2026-08-28):** corpus
-> **369**, **338 full + 18 wrappers = 356/369 delivery-ready**, 13 reduced cores, 0 placeholders.
-> Ledger 369 fresh / 0 stale / 0 missing; `lake build MathFin` and `lake lint` green, `pytest`
-> 50/50, `AxiomAuditGen` at 329 guards (234 curated). The **bracket compensator** below is the
-> newest round; the conditional bracket, the unconditional one, the **contracts tower**, the
-> **Itô chain rule**, and its coherence pass follow.
+> **Live status (2026-09-01):** corpus
+> **370**, **339 full + 18 wrappers = 357/370 delivery-ready**, 13 reduced cores, 0 placeholders.
+> Ledger 370 fresh / 0 stale / 0 missing; `lake build MathFin` and `lake lint` green, `pytest`
+> 50/50, `AxiomAuditGen` at 330 guards (239 curated). The **Glosten–Milgrom spread** below is the
+> newest round; the bracket compensator, the conditional bracket, the unconditional one, the
+> **contracts tower**, the **Itô chain rule**, and its coherence pass follow.
+>
+> **2026-09-01 — adverse selection alone sets the spread (369 → 370).** A new section
+> `MathFin/Execution/` opens with Glosten–Milgrom (1985). `Execution.spread_pos_of_model` proves
+> `∫ V ∂μ[|buy] > ∫ V ∂μ[|sell]` from the trader mix — the informed event independent of the
+> value, an informed trader buying exactly when the value is high, an uninformed trader tossing a
+> coin. Corpus entry `mf-glosten-milgrom-spread-positive`.
+>
+> **The trade probabilities are derived, not posited.** `P(buy | V_H) = (1+p)/2` and
+> `P(buy | V_L) = (1−p)/2` follow from the four primitives — the prior, the informed event
+> independent of the value, informed traders trading on the value, uninformed traders tossing a
+> coin — which is what makes this `full` rather than a restatement. They are stated additively
+> (`2 · μ[B|H] = 1 + p`, `2 · μ[B|Hᶜ] + p = 1`) so that no step forms a difference in a type where
+> subtraction truncates; the textbook form does follow from the additive one, so this buys the
+> proofs, not the statements. The quotes are honest Bochner integrals: with the payoff written as
+> a constant plus an indicator, integrability is one line and the asset cancels, leaving
+> `(V_H − V_L)` times the gap between the posteriors.
+>
+> **The seam is the load-bearing part.** `cond_toReal_eq` is Bayes pushed through `.toReal` once
+> and generically; it is what identifies the model's `μ[H | B]` with the real function `postBuy`
+> the closed form is about, and the buy and sell sides are then the same lemma applied twice with
+> the likelihoods swapped. Without it the measure-theoretic half and the real-analysis half are
+> true statements about unrelated objects. `toReal` sends `∞ ↦ 0` and `x/0 ↦ 0`, so every
+> conversion carries its `≠ ∞` side condition.
+>
+> **`0 < θ < 1` is a hypothesis the usual statement omits, and the endpoints fail two different
+> ways.** With `p < 1` a degenerate prior leaves nothing to be adversely selected: the posteriors
+> coincide, the spread is exactly `0`, and `ask − bid > 0` is false. With `p = 1` it is worse, in
+> two ways both machine-checked here: one trade event is null, and `quote_eq_zero_of_null` shows
+> `cond` then returns the *zero measure*, whose integral is `0` — not a bad price but no price;
+> and `spread_junk_at_corner` evaluates the closed form at `θ = 1, p = 1`, where it returns the
+> **entire** `V_H − V_L`, the largest spread there could be, at the one point where the true
+> spread is `0`, because `0/0 = 0`. Nothing errors in either case. The derivation demands the hypothesis independently: the two trade
+> probabilities need `μ H ≠ 0` and `μ Hᶜ ≠ 0`, so their hypotheses cannot be jointly satisfied
+> without it. Two further hypotheses proved unnecessary and were removed rather than shipped:
+> `p ≤ 1` is forced by `μ (H ∩ I) ≤ μ H`, and `μ H ≠ 0` in `postSell_eq` is forced by the trade
+> probability itself.
+>
+> **The hypotheses are satisfiable, and that is a theorem.** A conjunction of measure-theoretic
+> constraints proves nothing if no model meets it — the same failure this round is about, one
+> level up. `MathFin/Execution/GlostenMilgromModel.lean` exhibits a six-point space (value high or
+> low × informed or not × the uninformed trader's coin) discharging every hypothesis, symbolically
+> in `θ` and `p`, so `spread_pos_witness` states the conclusion with no measure-theoretic
+> hypothesis in front of it.
+>
+> **Not claimed, and this is the important half.** The competitive market maker is *not*
+> formalized: `ask = E[V | buy]` and `bid = E[V | sell]` are posited by the shape of the
+> conclusion, and Glosten–Milgrom's derivation of them from zero expected profit under competition
+> is the assumed part. The sell event is modelled as `Bᶜ`, so there is no no-trade outcome — under
+> the standard extension that admits one, `E[V | Bᶜ]` is not the bid. Nothing dynamic: no sequence
+> of trades, no convergence of quotes to the true value. The model is two-valued and one-period,
+> as in the paper's opening section.
 >
 > **2026-08-28 — the bracket is adapted, and it compensates `M²` (368 → 369).**
 > `BracketCompensator.condExp_sq_sub_bracket` proves

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -53,7 +53,7 @@ sources:
     author_endorsement: n/a
     note: Canonical results whose textbook statements the wider corpus tracks.
 status:
-  scope: 369 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 356 delivery-ready (full + library-wrapper).
+  scope: 370 theorems across continuous-time stochastic processes and mathematical finance, built on Mathlib + BrownianMotion; 357 delivery-ready (full + library-wrapper).
   sorry_count: 0
   sorry_in_definitions: 0
   axioms:
@@ -166,9 +166,9 @@ alignment:
       status: full 6 · wrapper 3 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: mathematical_finance (Saporito, Stochastic Processes)
-      lean: 252 statements
+      lean: 253 statements
       module: benchmarks/mathematical_finance.json
-      status: full 251 · wrapper 1 · reduced 0 · placeholder 0
+      status: full 252 · wrapper 1 · reduced 0 · placeholder 0
       note: per-statement map in docs/coverage.md
     - source: poisson_processes (Saporito, Stochastic Processes)
       lean: 5 statements

--- a/verification_ledger.json
+++ b/verification_ledger.json
@@ -1571,6 +1571,13 @@
       "input_hash": "9bacc46bd752b79068558a29cae50b0a71ad59d5b5d1a6f5006f141e301fed43",
       "verified_at_commit": "70acfe0"
     },
+    "mf-glosten-milgrom-spread-positive": {
+      "benchmark_file": "mathematical_finance.json",
+      "date": "2026-09-01",
+      "elapsed_s": 4.9,
+      "input_hash": "a947e2a936881c47c13d72d0bfbe99fd497556f240532203b16eba3e115fe496",
+      "verified_at_commit": "1f9d665"
+    },
     "mf-gompertz-cumulative-force": {
       "benchmark_file": "mathematical_finance.json",
       "date": "2026-08-20",


### PR DESCRIPTION
## Summary

Glosten–Milgrom (1985) in a new `MathFin/Execution/` section: the market maker's ask
strictly exceeds its bid, derived from the trader mix rather than from assumed trade
probabilities. `P(buy | V_H) = (1+p)/2` and `P(buy | V_L) = (1−p)/2` follow from the
four primitives, stated additively so no step forms a difference in `ℝ≥0∞`; the quotes
are Bochner integrals against the conditioned measures; and `cond_toReal_eq` — Bayes
pushed through `.toReal` once, generically — identifies the model's `μ[H | B]` with the
real function the closed form is about, which is what makes the parts one theorem rather
than three. A closed-form-only route was available and shorter, but lands `reduced_core`.

**The statement carries `0 < θ < 1`, which the acceptance criterion omits** — as flagged
in the thread. The closed form's numerator carries `θ(1−θ)`, which vanishes where the
value is common knowledge and nothing is adversely selected. Two theorems check this
rather than assert it: `spread_junk_at_corner` shows that at `θ = 1, π = 1` the formula
returns the *entire* `V_H − V_L` — the largest spread possible — at the one point where
the true spread is `0`, because `0/0 = 0` and nothing errors; `quote_eq_zero_of_null`
shows a null trade event gives no quote at all, `cond` returning the zero measure. The
derivation forces the hypothesis independently: the two trade probabilities need
`μ H ≠ 0` and `μ Hᶜ ≠ 0`, so their hypotheses cannot be jointly satisfied without it.

`GlostenMilgromModel.lean` closes the vacuity question: a six-point space satisfies every
hypothesis, symbolically in `θ` and `p`.

**Not claimed:** the competitive market maker is not formalized — `ask = E[V | buy]` and
`bid = E[V | sell]` are posited by the shape of the conclusion, not derived from zero
expected profit. The sell event is `Bᶜ`, so there is no no-trade outcome. Nothing dynamic:
one period, two-valued, as in the paper's opening section.

## Verification

37 theorems, no `sorry`, all `[propext, Classical.choice, Quot.sound]`. Corpus 369 → 370
(`full`); `AxiomAuditGen` 329 → 330, five curated entries added; `ledger status` 370 fresh,
0 stale, 0 missing; `lake build` and `lake lint` green; `pytest tests/ -q` 48 passed,
1 skipped. Per-file checks and pytest were run on the host (`lake env lean`, host `pytest`)
rather than through the GHCR image — happy to re-run in-container.

## Checklist

### For Lean proof contributions

- [x] Proof lives in `MathFin/<Section>/<Module>.lean`, not inlined in JSON.
- [x] `@[expose] public section` present in the module after the docstring.
- [x] `#print axioms` shows only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.
- [x] `lake build` exits cleanly.
- [x] Per-file check green (via `lake env lean`, see Verification).
- [x] Benchmark re-export shim added: `mf-glosten-milgrom-spread-positive`.
- [x] `metadata.formalization_status` = `full`.
- [x] `docs/coverage.md` entry added; `README.md` counts and inventory updated.
- [x] `axiom_audit_gen --write` re-run.
- [x] `ledger status` exits 0.
- [x] `pytest tests/ -q` passes (see Verification).

## Related issues

Closes #107
